### PR TITLE
Globalize components+update messages

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
-  </component>
-</project>

--- a/app/src/main/java/com/example/leveluplife/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/auth/LoginScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -22,15 +21,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowForward
 import androidx.compose.material.icons.outlined.Email
-import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,7 +47,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -63,7 +57,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.leveluplife.R
 import com.example.leveluplife.data.error.AuthError
+import com.example.leveluplife.ui.components.LulErrorAlertDialog
 import com.example.leveluplife.ui.components.LulLogo
+import com.example.leveluplife.ui.components.LulPrimaryButton
+import com.example.leveluplife.ui.components.LulScreenHeaderLabels
 import com.example.leveluplife.ui.components.ThemeToggleButton
 import com.example.leveluplife.ui.theme.ThemeController
 
@@ -153,34 +150,18 @@ private fun LoginContent(
 
             Spacer(Modifier.height(48.dp))
 
-            Text(
-                text = stringResource(R.string.login_welcome),
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground,
-                modifier = Modifier.semantics { heading() },
-            )
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.login_welcome_subtitle),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            LulScreenHeaderLabels(
+                title = stringResource(R.string.login_welcome),
+                subtitle = stringResource(R.string.login_welcome_subtitle),
+                titleTextStyle = MaterialTheme.typography.headlineMedium,
+                titleFontWeight = FontWeight.Bold,
+                titleColor = MaterialTheme.colorScheme.onBackground,
+                subtitleTextStyle = MaterialTheme.typography.bodyLarge,
+                subtitleColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                gapAfterTitle = 4.dp,
             )
 
             Spacer(Modifier.height(28.dp))
-
-            // Banner de error global
-            if (state.bannerError != null) {
-                ErrorBanner(
-                    error = state.bannerError,
-                    onDismiss = onDismissError,
-                    onRetry = if (state.bannerError is AuthError.Network) onSubmit else null,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 16.dp)
-                        .testTag(LoginTestTags.ERROR_BANNER),
-                )
-            }
-
             // Email o usuario
             val emailFieldLabel = stringResource(R.string.login_email_placeholder)
             OutlinedTextField(
@@ -271,44 +252,24 @@ private fun LoginContent(
 
             Spacer(Modifier.height(20.dp))
 
-            Button(
+            LulPrimaryButton(
+                text = stringResource(R.string.login_submit),
                 onClick = {
                     focusManager.clearFocus()
                     onSubmit()
                 },
                 enabled = !state.isLoading,
+                isLoading = state.isLoading,
                 shape = RoundedCornerShape(28.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary,
                     disabledContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
                 ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp)
-                    .testTag(LoginTestTags.SUBMIT_BUTTON),
-            ) {
-                if (state.isLoading) {
-                    CircularProgressIndicator(
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        strokeWidth = 2.5.dp,
-                        modifier = Modifier
-                            .size(22.dp)
-                            .testTag(LoginTestTags.LOADING),
-                    )
-                } else {
-                    Text(
-                        text = stringResource(R.string.login_submit),
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 1.sp,
-                    )
-                    Spacer(Modifier.width(10.dp))
-                    Icon(
-                        imageVector = Icons.Outlined.ArrowForward,
-                        contentDescription = null,
-                    )
-                }
-            }
+                buttonHeight = 56.dp,
+                modifier = Modifier.testTag(LoginTestTags.SUBMIT_BUTTON),
+                loadingTestTag = LoginTestTags.LOADING,
+            )
 
             Spacer(Modifier.height(40.dp))
         }
@@ -341,53 +302,24 @@ private fun LoginContent(
                 )
             }
         }
-    }
-}
 
-@Composable
-private fun ErrorBanner(
-    error: AuthError,
-    onDismiss: () -> Unit,
-    onRetry: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .background(
-                color = MaterialTheme.colorScheme.errorContainer,
-                shape = RoundedCornerShape(12.dp),
-            )
-            .padding(horizontal = 12.dp, vertical = 10.dp)
-            .semantics { contentDescription = "Error" },
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.ErrorOutline,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onErrorContainer,
-        )
-        Spacer(Modifier.width(10.dp))
-        Text(
-            text = error.toMessage(),
-            color = MaterialTheme.colorScheme.onErrorContainer,
-            modifier = Modifier.weight(1f),
-        )
-        if (onRetry != null) {
-            TextButton(
-                onClick = onRetry,
-                modifier = Modifier.testTag(LoginTestTags.RETRY_BUTTON),
-            ) {
-                Text(
-                    text = stringResource(R.string.login_retry),
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-        }
-        TextButton(onClick = onDismiss) {
-            Text(
-                text = stringResource(R.string.login_dismiss),
-                color = MaterialTheme.colorScheme.onErrorContainer,
+        state.bannerError?.let { error ->
+            LulErrorAlertDialog(
+                title = stringResource(R.string.error_dialog_title),
+                message = error.toMessage(),
+                dismissText = stringResource(R.string.login_dismiss),
+                onDismiss = onDismissError,
+                titleTextStyle = MaterialTheme.typography.titleLarge,
+                messageTextStyle = MaterialTheme.typography.bodyMedium,
+                iconTint = MaterialTheme.colorScheme.error,
+                retryText = if (error is AuthError.Network) {
+                    stringResource(R.string.login_retry)
+                } else {
+                    null
+                },
+                onRetry = if (error is AuthError.Network) onSubmit else null,
+                retryTestTag = LoginTestTags.RETRY_BUTTON,
+                errorTestTag = LoginTestTags.ERROR_BANNER,
             )
         }
     }

--- a/app/src/main/java/com/example/leveluplife/ui/components/LulErrorAlertDialog.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/components/LulErrorAlertDialog.kt
@@ -1,0 +1,63 @@
+package com.example.leveluplife.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+fun LulErrorAlertDialog(
+    title: String,
+    message: String,
+    dismissText: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    titleTextStyle: TextStyle = MaterialTheme.typography.titleLarge,
+    messageTextStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    iconTint: Color = MaterialTheme.colorScheme.error,
+    retryText: String? = null,
+    onRetry: (() -> Unit)? = null,
+    retryTestTag: String? = null,
+    errorTestTag: String? = null,
+) {
+    val dialogModifier = if (errorTestTag != null) modifier.testTag(errorTestTag) else modifier
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = dialogModifier,
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.ErrorOutline,
+                contentDescription = null,
+                tint = iconTint,
+            )
+        },
+        title = { Text(text = title, style = titleTextStyle) },
+        text = { Text(text = message, style = messageTextStyle) },
+        dismissButton = if (onRetry != null && retryText != null) {
+            {
+                TextButton(
+                    onClick = onRetry,
+                    modifier = if (retryTestTag != null) Modifier.testTag(retryTestTag) else Modifier,
+                ) {
+                    Text(text = retryText)
+                }
+            }
+        } else {
+            null
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = dismissText)
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/example/leveluplife/ui/components/LulPrimaryButton.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/components/LulPrimaryButton.kt
@@ -1,0 +1,84 @@
+package com.example.leveluplife.ui.components
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowForward
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun LulPrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isLoading: Boolean = false,
+    shape: Shape = RoundedCornerShape(28.dp),
+    colors: ButtonColors = ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        disabledContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+    ),
+    buttonHeight: Dp = 56.dp,
+    trailingIcon: ImageVector = Icons.Outlined.ArrowForward,
+    textFontWeight: FontWeight = FontWeight.Bold,
+    textLetterSpacing: TextUnit = 1.sp,
+    loadingIndicatorColor: Color = MaterialTheme.colorScheme.onPrimary,
+    loadingStrokeWidth: Dp = 2.5.dp,
+    loadingIndicatorSize: Dp = 22.dp,
+    loadingTestTag: String? = null,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled && !isLoading,
+        shape = shape,
+        colors = colors,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(buttonHeight),
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = loadingIndicatorColor,
+                strokeWidth = loadingStrokeWidth,
+                modifier = Modifier
+                    .size(loadingIndicatorSize)
+                    .then(
+                        if (loadingTestTag != null) Modifier.testTag(loadingTestTag) else Modifier,
+                    ),
+            )
+        } else {
+            Text(
+                text = text,
+                fontWeight = textFontWeight,
+                letterSpacing = textLetterSpacing,
+            )
+            Spacer(Modifier.width(10.dp))
+            Icon(
+                imageVector = trailingIcon,
+                contentDescription = null,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/components/LulScreenHeaderLabels.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/components/LulScreenHeaderLabels.kt
@@ -1,0 +1,48 @@
+package com.example.leveluplife.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LulScreenHeaderLabels(
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    titleTextStyle: TextStyle = MaterialTheme.typography.headlineMedium,
+    titleFontWeight: FontWeight = FontWeight.Bold,
+    titleColor: Color = MaterialTheme.colorScheme.onBackground,
+    titleModifier: Modifier = Modifier.semantics { heading() },
+    subtitleTextStyle: TextStyle = MaterialTheme.typography.bodyLarge,
+    subtitleColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    subtitleModifier: Modifier = Modifier,
+    gapAfterTitle: Dp = 4.dp,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = title,
+            style = titleTextStyle,
+            fontWeight = titleFontWeight,
+            color = titleColor,
+            modifier = titleModifier,
+        )
+        Spacer(Modifier.height(gapAfterTitle))
+        Text(
+            text = subtitle,
+            style = subtitleTextStyle,
+            color = subtitleColor,
+            modifier = subtitleModifier,
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="login_register_cta">REGÍSTRATE</string>
     <string name="login_retry">Reintentar</string>
     <string name="login_dismiss">Cerrar</string>
+    <string name="error_dialog_title">Error</string>
 
     <!-- Login: errores -->
     <string name="login_error_invalid_credentials">Usuario/email o contraseña incorrectos</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.1"
+agp = "8.7.2"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This change introduces three reusable Compose components (`LulPrimaryButton`, `LulScreenHeaderLabels`, `LulErrorAlertDialog`) under `ui/components`, with sensible defaults from `MaterialTheme`. **Login** adopts them and passes explicit colors, shapes, and typography so the screen keeps the same look and behavior as before.

Banner-style auth errors on login are now shown in a **shared `AlertDialog`** instead of an inline error strip inside the scroll column. **Strings**: added `error_dialog_title` for the dialog title.

**Build:** Android Gradle Plugin is downgraded from **9.2.1** to **8.7.2** and the Gradle wrapper to **8.10.2** so the project syncs with Android Studio versions that do not support AGP 9.x yet.

---

## 🎯 Purpose

**HU #52:** Centralize the primary CTA, header labels, and error presentation so they can be reused elsewhere, while keeping login-specific layout (fields, register footer, logo row) in `LoginScreen`.

**Build fix:** Resolve the IDE error *“incompatible version (AGP 9.2.1) … latest supported is AGP 8.7.2”* so contributors can open and build the project on supported Studio/AGP combinations.

---

## 🔄 Type of Change

Please check the relevant option:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Explain the testing process:

- Sync project with Android Studio after AGP/Gradle change; confirm no AGP compatibility warning.
- **Login:** submit with valid/invalid input; confirm header, primary button (including loading), and footer behave as before.
- **Errors:** trigger a banner-level error (e.g. validation or network); confirm **`LulErrorAlertDialog`** appears, **Close** clears the error, and **Retry** appears only for network errors when applicable.
- (Optional) Run `./gradlew :app:compileDebugKotlin` / assemble if CI is not wired.

---

## 📸 Screenshots (if applicable)
### New messages form
<img width="1220" height="2712" alt="image" src="https://github.com/user-attachments/assets/2118cf38-526a-4e5b-be3e-41be3be23f1c" />

_N/A — visual parity with previous login; dialog replaces inline error banner._

---

## 🚀 Deployment Notes (if needed)

Are there any special steps required for deployment?

- First sync may download **Gradle 8.10.2** via the wrapper.
- No server or API changes.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [ ] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #52
Linked to #52