### PR TITLE
7 frontend list repetition criteria

### DIFF
--- a/app/src/main/java/com/example/leveluplife/data/habits/HabitRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/habits/HabitRepository.kt
@@ -1,11 +1,13 @@
 package com.example.leveluplife.data.habits
 
 import com.example.leveluplife.data.network.HabitsApi
+import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.network.dto.HabitsPageResponse
 import com.example.leveluplife.data.network.dto.PaginationDto
 
 interface HabitRepository {
     suspend fun getActiveHabits(page: Int, pageSize: Int = 10): Result<HabitsPageResponse>
+    suspend fun getHabitById(id: Int): Result<HabitDto>
 }
 
 class DefaultHabitRepository(private val api: HabitsApi) : HabitRepository {
@@ -26,6 +28,17 @@ class DefaultHabitRepository(private val api: HabitsApi) : HabitRepository {
                     ),
                 )
             )
+            else -> Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (t: Throwable) {
+        Result.failure(t)
+    }
+
+    override suspend fun getHabitById(id: Int): Result<HabitDto> = try {
+        val response = api.getHabitById(id)
+        when {
+            response.isSuccessful -> Result.success(requireNotNull(response.body()))
+            response.code() == 404 -> Result.failure(Exception("Hábito no encontrado"))
             else -> Result.failure(Exception("HTTP ${response.code()}"))
         }
     } catch (t: Throwable) {

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
@@ -1,8 +1,10 @@
 package com.example.leveluplife.data.network
 
+import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.network.dto.HabitsPageResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface HabitsApi {
@@ -11,4 +13,7 @@ interface HabitsApi {
         @Query("pageNumber") pageNumber: Int,
         @Query("pageSize") pageSize: Int,
     ): Response<HabitsPageResponse>
+
+    @GET("api/Habits/{id}")
+    suspend fun getHabitById(@Path("id") id: Int): Response<HabitDto>
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/HabitDto.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/HabitDto.kt
@@ -16,7 +16,31 @@ data class HabitDto(
 )
 
 @Serializable
-data class HabitTaskDto(val id: Int)
+data class RepetitionCriteriaDto(
+    val id: Int,
+    val habitTaskId: Int,
+    val repetitions: Int = 0,
+    val measurementUnit: String = "",
+    val isPartialAllowed: Boolean = false,
+    val isActive: Boolean = false,
+) {
+    fun toReadableSummary(): String {
+        val unit = when (measurementUnit.uppercase()) {
+            "REPS" -> if (repetitions == 1) "repetición" else "repeticiones"
+            "SERIES" -> if (repetitions == 1) "serie" else "series"
+            "KMS" -> "km"
+            "CALS" -> "cal"
+            else -> measurementUnit.lowercase()
+        }
+        return "$repetitions $unit"
+    }
+}
+
+@Serializable
+data class HabitTaskDto(
+    val id: Int,
+    val repetitionCriteria: RepetitionCriteriaDto? = null,
+)
 
 @Serializable
 data class PaginationDto(

--- a/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailScreen.kt
@@ -1,0 +1,346 @@
+package com.example.leveluplife.ui.habitdetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.leveluplife.data.network.dto.HabitDto
+import com.example.leveluplife.data.network.dto.RepetitionCriteriaDto
+import com.example.leveluplife.ui.theme.DarkBackground
+import com.example.leveluplife.ui.theme.DarkOnBackground
+import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
+import com.example.leveluplife.ui.theme.DarkSurfaceVariant
+import com.example.leveluplife.ui.theme.PurplePrimary
+import com.example.leveluplife.ui.theme.PurplePrimaryContainer
+
+private val GreenSuccess = Color(0xFF4CAF50)
+private val OrangeWarn = Color(0xFFF59E0B)
+
+@Composable
+fun HabitDetailScreen(
+    viewModel: HabitDetailViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = DarkBackground,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Regresar",
+                        tint = DarkOnBackground,
+                    )
+                }
+                Text(
+                    text = state.habit?.title ?: "Detalle del hábito",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = DarkOnBackground,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(
+                        color = PurplePrimary,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(44.dp),
+                    )
+                }
+
+                state.error != null -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "",
+                            color = DarkOnSurfaceVariant,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(horizontal = 32.dp),
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.loadHabit() }) {
+                            Text("Reintentar", color = PurplePrimary)
+                        }
+                    }
+                }
+
+                state.habit != null -> HabitDetailContent(habit = requireNotNull(state.habit))
+            }
+        }
+    }
+}
+
+@Composable
+private fun HabitDetailContent(habit: HabitDto) {
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { HabitInfoCard(habit) }
+
+        if (habit.tasks.isNotEmpty()) {
+            item {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "CRITERIOS DE REPETICIÓN",
+                    fontSize = 11.sp,
+                    letterSpacing = 2.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = DarkOnSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
+            itemsIndexed(habit.tasks) { index, task ->
+                TaskCriteriaCard(
+                    taskNumber = index + 1,
+                    criteria = task.repetitionCriteria,
+                )
+            }
+        }
+
+        item { Spacer(Modifier.height(8.dp)) }
+    }
+}
+
+@Composable
+private fun HabitInfoCard(habit: HabitDto) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(18.dp)) {
+            Text(
+                text = habit.title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = DarkOnBackground,
+            )
+
+            val meta = listOfNotNull(
+                habit.categoryName.takeIf { it.isNotBlank() },
+                habit.disciplineName.takeIf { it.isNotBlank() },
+            ).joinToString(" · ")
+            if (meta.isNotBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = meta,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = DarkOnSurfaceVariant,
+                )
+            }
+
+            if (habit.description.isNotBlank()) {
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    text = habit.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = DarkOnBackground,
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                val taskCount = habit.tasks.size
+                val withCriteria = habit.tasks.count { it.repetitionCriteria != null }
+
+                Box(
+                    modifier = Modifier
+                        .background(PurplePrimaryContainer, RoundedCornerShape(8.dp))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = "$taskCount ${if (taskCount == 1) "tarea" else "tareas"}",
+                        fontSize = 12.sp,
+                        color = PurplePrimary,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+
+                if (withCriteria > 0) {
+                    Spacer(Modifier.width(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .background(
+                                GreenSuccess.copy(alpha = 0.15f),
+                                RoundedCornerShape(8.dp),
+                            )
+                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = "$withCriteria con criterios",
+                            fontSize = 12.sp,
+                            color = GreenSuccess,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaskCriteriaCard(
+    taskNumber: Int,
+    criteria: RepetitionCriteriaDto?,
+) {
+    Card(
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(42.dp)
+                    .background(PurplePrimaryContainer, RoundedCornerShape(11.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Filled.FitnessCenter,
+                    contentDescription = null,
+                    tint = PurplePrimary,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+
+            Spacer(Modifier.width(14.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Objetivo $taskNumber",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = DarkOnBackground,
+                )
+
+                if (criteria != null) {
+                    Spacer(Modifier.height(6.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CriteriaChip(
+                            label = criteria.toReadableSummary(),
+                            background = PurplePrimaryContainer,
+                            textColor = PurplePrimary,
+                        )
+                        if (criteria.isPartialAllowed) {
+                            CriteriaChip(
+                                label = "Admite parcial",
+                                background = OrangeWarn.copy(alpha = 0.15f),
+                                textColor = OrangeWarn,
+                            )
+                        }
+                        if (!criteria.isActive) {
+                            CriteriaChip(
+                                label = "Inactivo",
+                                background = DarkOnSurfaceVariant.copy(alpha = 0.12f),
+                                textColor = DarkOnSurfaceVariant,
+                            )
+                        }
+                    }
+                } else {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "Sin criterios de repetición",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = DarkOnSurfaceVariant,
+                    )
+                }
+            }
+
+            if (criteria?.isActive == true) {
+                Icon(
+                    Icons.Filled.CheckCircle,
+                    contentDescription = "Activo",
+                    tint = GreenSuccess,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CriteriaChip(
+    label: String,
+    background: Color,
+    textColor: Color,
+) {
+    Box(
+        modifier = Modifier
+            .background(background, RoundedCornerShape(6.dp))
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+    ) {
+        Text(
+            text = label,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            color = textColor,
+        )
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailUiState.kt
@@ -1,0 +1,9 @@
+package com.example.leveluplife.ui.habitdetail
+
+import com.example.leveluplife.data.network.dto.HabitDto
+
+data class HabitDetailUiState(
+    val habit: HabitDto? = null,
+    val isLoading: Boolean = true,
+    val error: String? = null,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailViewModel.kt
@@ -1,0 +1,48 @@
+package com.example.leveluplife.ui.habitdetail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.leveluplife.data.habits.HabitRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class HabitDetailViewModel(
+    private val habitRepository: HabitRepository,
+    private val habitId: Int,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(HabitDetailUiState())
+    val state: StateFlow<HabitDetailUiState> = _state.asStateFlow()
+
+    init {
+        loadHabit()
+    }
+
+    fun loadHabit() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+            habitRepository.getHabitById(habitId)
+                .onSuccess { habit ->
+                    _state.update { it.copy(isLoading = false, habit = habit) }
+                }
+                .onFailure { t ->
+                    _state.update { it.copy(isLoading = false, error = t.message ?: "Error desconocido") }
+                }
+        }
+    }
+
+    class Factory(
+        private val habitRepository: HabitRepository,
+        private val habitId: Int,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(HabitDetailViewModel::class.java))
+            return HabitDetailViewModel(habitRepository, habitId) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
@@ -77,6 +77,7 @@ private val OrangeFire = Color(0xFFF59E0B)
 fun HomeScreen(
     viewModel: HomeViewModel,
     onLoggedOut: () -> Unit,
+    onHabitClick: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -185,7 +186,7 @@ fun HomeScreen(
 
                 else -> {
                     items(state.habits, key = { it.id }) { habit ->
-                        HabitCard(habit = habit)
+                        HabitCard(habit = habit, onClick = { onHabitClick(habit.id) })
                         Spacer(Modifier.height(10.dp))
                     }
                     if (state.isLoadingMore) {
@@ -393,8 +394,9 @@ private fun CalendarWeekCard() {
 }
 
 @Composable
-private fun HabitCard(habit: HabitDto) {
+private fun HabitCard(habit: HabitDto, onClick: () -> Unit = {}) {
     Card(
+        onClick = onClick,
         shape = RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -4,18 +4,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.example.leveluplife.AppContainer
 import com.example.leveluplife.ui.auth.LoginScreen
 import com.example.leveluplife.ui.auth.LoginViewModel
+import com.example.leveluplife.ui.habitdetail.HabitDetailScreen
+import com.example.leveluplife.ui.habitdetail.HabitDetailViewModel
 import com.example.leveluplife.ui.home.HomeScreen
 import com.example.leveluplife.ui.home.HomeViewModel
 
 object Routes {
     const val LOGIN = "login"
     const val DASHBOARD = "dashboard"
+    const val HABIT_DETAIL = "habit_detail/{habitId}"
+    fun habitDetail(id: Int) = "habit_detail/$id"
 }
 
 @Composable
@@ -66,6 +72,22 @@ fun AppNavigation(
                         launchSingleTop = true
                     }
                 },
+                onHabitClick = { habitId ->
+                    navController.navigate(Routes.habitDetail(habitId))
+                },
+            )
+        }
+        composable(
+            route = Routes.HABIT_DETAIL,
+            arguments = listOf(navArgument("habitId") { type = NavType.IntType }),
+        ) { backStackEntry ->
+            val habitId = backStackEntry.arguments?.getInt("habitId") ?: return@composable
+            val vm: HabitDetailViewModel = viewModel(
+                factory = HabitDetailViewModel.Factory(container.habitRepository, habitId),
+            )
+            HabitDetailScreen(
+                viewModel = vm,
+                onBack = { navController.popBackStack() },
             )
         }
     }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements the habit detail screen for the LevelUpLife Android app. When a user taps on a habit card in the home list, they are navigated to a detail screen that displays the habit's full information along with a human-readable summary of each task's repetition criteria (e.g., "3 series", "5 km", "10 repeticiones").

The implementation also expands the existing `HabitTaskDto` and adds a new `RepetitionCriteriaDto` to correctly deserialize the nested data returned by `GET /api/Habits/{id}`.

---

## 🎯 Purpose

Previously, the app only listed habits with minimal info (title, category, discipline). Users had no way to understand the repetition schedule or objective behind each habit's tasks.

This change gives users visibility into **what** they need to do and **how much**, fulfilling the user story:

> *"As a user, I want to understand repetition schedules so I can plan when to perform tasks."*

**Note on endpoint:** The original task specified a standalone `GET /criteria/repetition` endpoint. Following QA feedback, repetition criteria creation was integrated into the `POST /api/Habits` flow. The `GET /api/Habits/{id}` endpoint already returns tasks with their nested `repetitionCriteria`, so no additional endpoint was needed.

---

## 🔄 Type of Change

- [x] ✨ New feature

---

## 🧪 How Has This Been Tested?

- [x] Manual testing

**Testing process:**

1. Created a habit via `POST /api/Habits` with a task including `repetitionCriteria` (e.g., `repetitions: 3, measurementUnit: "SERIES", isPartialAllowed: true`).
2. Launched the app, confirmed the habit appears in the home list.
3. Tapped the habit card — navigated correctly to the detail screen.
4. Verified the detail screen shows:
   - Habit title, description, category · discipline
   - Task count and "con criterios" chips
   - "Objetivo 1" card with "3 series" chip (readable summary)
   - "Admite parcial" orange chip when `isPartialAllowed: true`
   - Green checkmark when `isActive: true`
5. Verified back navigation returns to the home list without state loss.
6. Verified error state displays a "Reintentar" button when the request fails.
7. Confirmed `BUILD SUCCESSFUL` with no new errors or warnings introduced.

---

## 📸 Screenshots (if applicable)

<img width="346" height="514" alt="image" src="https://github.com/user-attachments/assets/9d2e8221-9434-40ab-8e1a-9a5ac8778d9d" />

## 🚀 Deployment Notes (if needed)

No special deployment steps required. The `GET /api/Habits/{id}` endpoint already exists in the backend and returns the expected structure.

---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #7  
Linked to #30
