### PR TITLE
feat(categories): add categories index with search and pagination  - …

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,13 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-06-14T04:16:16.678939700Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Jason Madrigal\.android\avd\Resizable_Experimental.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
         <DialogSelection />
       </SelectionState>
     </selectionStates>

--- a/app/src/main/java/com/example/leveluplife/AppContainer.kt
+++ b/app/src/main/java/com/example/leveluplife/AppContainer.kt
@@ -5,9 +5,12 @@ import com.example.leveluplife.data.auth.AuthRepository
 import com.example.leveluplife.data.auth.DefaultAuthRepository
 import com.example.leveluplife.data.auth.EncryptedTokenStore
 import com.example.leveluplife.data.auth.TokenStore
+import com.example.leveluplife.data.categories.DefaultHabitCategoryRepository
+import com.example.leveluplife.data.categories.HabitCategoryRepository
 import com.example.leveluplife.data.habits.DefaultHabitRepository
 import com.example.leveluplife.data.habits.HabitRepository
 import com.example.leveluplife.data.network.AuthApi
+import com.example.leveluplife.data.network.HabitCategoriesApi
 import com.example.leveluplife.data.network.HabitsApi
 import com.example.leveluplife.data.network.HostProvider
 import com.example.leveluplife.data.network.NetworkModule
@@ -37,6 +40,9 @@ class AppContainer(applicationContext: Context) {
     }
     private val authApi: AuthApi by lazy { NetworkModule.provideAuthApi(retrofit) }
     private val habitsApi: HabitsApi by lazy { NetworkModule.provideHabitsApi(retrofit) }
+    private val habitCategoriesApi: HabitCategoriesApi by lazy {
+        NetworkModule.provideHabitCategoriesApi(retrofit)
+    }
 
     val authRepository: AuthRepository by lazy {
         DefaultAuthRepository(
@@ -48,5 +54,9 @@ class AppContainer(applicationContext: Context) {
 
     val habitRepository: HabitRepository by lazy {
         DefaultHabitRepository(api = habitsApi)
+    }
+
+    val habitCategoryRepository: HabitCategoryRepository by lazy {
+        DefaultHabitCategoryRepository(api = habitCategoriesApi)
     }
 }

--- a/app/src/main/java/com/example/leveluplife/data/categories/HabitCategoryRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/categories/HabitCategoryRepository.kt
@@ -1,0 +1,44 @@
+package com.example.leveluplife.data.categories
+
+import com.example.leveluplife.data.network.HabitCategoriesApi
+import com.example.leveluplife.data.network.dto.HabitCategoriesPageResponse
+import com.example.leveluplife.data.network.dto.PaginationDto
+
+interface HabitCategoryRepository {
+    suspend fun getActiveCategories(
+        page: Int,
+        pageSize: Int = 10,
+        search: String? = null,
+    ): Result<HabitCategoriesPageResponse>
+}
+
+class DefaultHabitCategoryRepository(
+    private val api: HabitCategoriesApi,
+) : HabitCategoryRepository {
+
+    override suspend fun getActiveCategories(
+        page: Int,
+        pageSize: Int,
+        search: String?,
+    ): Result<HabitCategoriesPageResponse> = try {
+        val response = api.getActiveCategories(page, pageSize, search?.takeIf { it.isNotBlank() })
+        when {
+            response.isSuccessful -> Result.success(requireNotNull(response.body()))
+            response.code() == 400 -> Result.success(
+                HabitCategoriesPageResponse(
+                    success = true,
+                    categories = emptyList(),
+                    pagination = PaginationDto(
+                        currentPage = page,
+                        pageSize = pageSize,
+                        totalPages = 1,
+                        totalRecords = 0,
+                    ),
+                )
+            )
+            else -> Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (t: Throwable) {
+        Result.failure(t)
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitCategoriesApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitCategoriesApi.kt
@@ -1,0 +1,15 @@
+package com.example.leveluplife.data.network
+
+import com.example.leveluplife.data.network.dto.HabitCategoriesPageResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface HabitCategoriesApi {
+    @GET("api/HabitCategory/list")
+    suspend fun getActiveCategories(
+        @Query("pageNumber") pageNumber: Int,
+        @Query("pageSize") pageSize: Int,
+        @Query("search") search: String? = null,
+    ): Response<HabitCategoriesPageResponse>
+}

--- a/app/src/main/java/com/example/leveluplife/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/NetworkModule.kt
@@ -51,5 +51,8 @@ object NetworkModule {
 
     fun provideHabitsApi(retrofit: Retrofit): HabitsApi = retrofit.create(HabitsApi::class.java)
 
+    fun provideHabitCategoriesApi(retrofit: Retrofit): HabitCategoriesApi =
+        retrofit.create(HabitCategoriesApi::class.java)
+
     fun jsonParser(): Json = json
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/HabitCategoryDto.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/HabitCategoryDto.kt
@@ -1,0 +1,23 @@
+package com.example.leveluplife.data.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HabitCategoryDto(
+    val id: Int,
+    val name: String = "",
+    val description: String = "",
+    val imageUrl: String? = null,
+    val habitsCount: Int = 0,
+    val isActive: Boolean = false,
+)
+
+@Serializable
+data class HabitCategoriesPageResponse(
+    val success: Boolean = false,
+    @SerialName("data")
+    val categories: List<HabitCategoryDto>? = null,
+    val pagination: PaginationDto? = null,
+    val message: String? = null,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/categories/CategoriesScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/categories/CategoriesScreen.kt
@@ -1,0 +1,351 @@
+package com.example.leveluplife.ui.categories
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.leveluplife.data.network.dto.HabitCategoryDto
+import com.example.leveluplife.ui.theme.DarkBackground
+import com.example.leveluplife.ui.theme.DarkOnBackground
+import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
+import com.example.leveluplife.ui.theme.DarkSurfaceVariant
+import com.example.leveluplife.ui.theme.PurplePrimary
+import com.example.leveluplife.ui.theme.PurplePrimaryContainer
+
+@Composable
+fun CategoriesScreen(
+    viewModel: CategoriesViewModel,
+    onBack: () -> Unit,
+    onCategoryClick: (HabitCategoryDto) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+    val listState = rememberLazyListState()
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val total = listState.layoutInfo.totalItemsCount
+            state.hasMore && !state.isLoadingMore && total > 0 && lastVisible >= total - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) viewModel.loadMore()
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = DarkBackground,
+    ) { innerPadding ->
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                top = innerPadding.calculateTopPadding() + 24.dp,
+                bottom = innerPadding.calculateBottomPadding() + 16.dp,
+                start = 20.dp,
+                end = 20.dp,
+            ),
+        ) {
+            item {
+                CategoriesHeader(onBack = onBack)
+                Spacer(Modifier.height(20.dp))
+                CategoriesSearchField(
+                    query = state.searchQuery,
+                    onQueryChange = viewModel::onSearchQueryChange,
+                )
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = "CATEGORÍAS DE HÁBITOS",
+                    fontSize = 11.sp,
+                    letterSpacing = 2.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = DarkOnSurfaceVariant,
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            when {
+                state.isLoading -> item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(
+                            color = DarkOnSurfaceVariant,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(44.dp),
+                        )
+                    }
+                }
+
+                state.error != null -> item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(150.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = state.error ?: "",
+                            color = DarkOnSurfaceVariant,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+
+                state.categories.isEmpty() -> item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(150.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = if (state.searchQuery.isBlank()) {
+                                "No hay categorías disponibles"
+                            } else {
+                                "No se encontraron categorías para \"${state.searchQuery}\""
+                            },
+                            color = DarkOnSurfaceVariant,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+
+                else -> {
+                    items(state.categories, key = { it.id }) { category ->
+                        CategoryCard(
+                            category = category,
+                            onClick = { onCategoryClick(category) },
+                        )
+                        Spacer(Modifier.height(10.dp))
+                    }
+                    if (state.isLoadingMore) {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 16.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(
+                                    color = PurplePrimary,
+                                    modifier = Modifier.size(28.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoriesHeader(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier
+                .background(DarkSurfaceVariant, RoundedCornerShape(14.dp))
+                .size(46.dp),
+        ) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "Volver",
+                tint = DarkOnBackground,
+            )
+        }
+        Spacer(Modifier.width(14.dp))
+        Text(
+            text = "CATEGORÍAS",
+            color = PurplePrimary,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 22.sp,
+            letterSpacing = 1.sp,
+        )
+    }
+}
+
+@Composable
+private fun CategoriesSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        shape = RoundedCornerShape(16.dp),
+        placeholder = {
+            Text("Buscar categorías…", color = DarkOnSurfaceVariant)
+        },
+        leadingIcon = {
+            Icon(
+                Icons.Filled.Search,
+                contentDescription = null,
+                tint = DarkOnSurfaceVariant,
+            )
+        },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        Icons.Filled.Close,
+                        contentDescription = "Limpiar búsqueda",
+                        tint = DarkOnSurfaceVariant,
+                    )
+                }
+            }
+        },
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedContainerColor = DarkSurfaceVariant,
+            unfocusedContainerColor = DarkSurfaceVariant,
+            focusedBorderColor = PurplePrimary,
+            unfocusedBorderColor = Color.Transparent,
+            focusedTextColor = DarkOnBackground,
+            unfocusedTextColor = DarkOnBackground,
+            cursorColor = PurplePrimary,
+        ),
+    )
+}
+
+@Composable
+private fun CategoryCard(
+    category: HabitCategoryDto,
+    onClick: () -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CategoryImage(category = category)
+            Spacer(Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = category.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = DarkOnBackground,
+                )
+                if (category.description.isNotBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = category.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = DarkOnSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+                HabitsCountBadge(count = category.habitsCount)
+            }
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = DarkOnSurfaceVariant,
+            )
+        }
+    }
+}
+
+// Mientras el backend no provea imageUrl, se muestra la inicial de la
+// categoría como imagen de respaldo.
+@Composable
+fun CategoryImage(
+    category: HabitCategoryDto,
+    modifier: Modifier = Modifier,
+    size: androidx.compose.ui.unit.Dp = 56.dp,
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .background(PurplePrimaryContainer, RoundedCornerShape(14.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = category.name.trim().take(1).uppercase().ifBlank { "?" },
+            color = PurplePrimary,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 22.sp,
+        )
+    }
+}
+
+@Composable
+fun HabitsCountBadge(count: Int, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.background(PurplePrimaryContainer, RoundedCornerShape(50.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = if (count == 1) "1 hábito" else "$count hábitos",
+            color = PurplePrimary,
+            fontWeight = FontWeight.Bold,
+            fontSize = 11.sp,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/categories/CategoriesUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/categories/CategoriesUiState.kt
@@ -1,0 +1,14 @@
+package com.example.leveluplife.ui.categories
+
+import com.example.leveluplife.data.network.dto.HabitCategoryDto
+
+data class CategoriesUiState(
+    val categories: List<HabitCategoryDto> = emptyList(),
+    val searchQuery: String = "",
+    val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val error: String? = null,
+    val currentPage: Int = 1,
+    val totalPages: Int = 1,
+    val hasMore: Boolean = false,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/categories/CategoriesViewModel.kt
@@ -1,0 +1,105 @@
+package com.example.leveluplife.ui.categories
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.leveluplife.data.categories.HabitCategoryRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class CategoriesViewModel(
+    private val categoryRepository: HabitCategoryRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(CategoriesUiState())
+    val state: StateFlow<CategoriesUiState> = _state.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    init {
+        loadCategories()
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _state.update { it.copy(searchQuery = query) }
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(SEARCH_DEBOUNCE_MS)
+            loadCategories()
+        }
+    }
+
+    fun loadCategories() {
+        viewModelScope.launch {
+            _state.update {
+                it.copy(isLoading = true, error = null, categories = emptyList(), currentPage = 1)
+            }
+            categoryRepository.getActiveCategories(page = 1, search = currentSearch())
+                .onSuccess { response ->
+                    val pagination = response.pagination
+                    val page = pagination?.currentPage ?: 1
+                    val total = pagination?.totalPages ?: 1
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            categories = response.categories ?: emptyList(),
+                            currentPage = page,
+                            totalPages = total,
+                            hasMore = page < total,
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update { it.copy(isLoading = false, error = t.message ?: "Error desconocido") }
+                }
+        }
+    }
+
+    fun loadMore() {
+        val current = _state.value
+        if (current.isLoadingMore || !current.hasMore) return
+        val nextPage = current.currentPage + 1
+        viewModelScope.launch {
+            _state.update { it.copy(isLoadingMore = true) }
+            categoryRepository.getActiveCategories(page = nextPage, search = currentSearch())
+                .onSuccess { response ->
+                    val pagination = response.pagination
+                    val page = pagination?.currentPage ?: nextPage
+                    val total = pagination?.totalPages ?: current.totalPages
+                    _state.update {
+                        it.copy(
+                            isLoadingMore = false,
+                            categories = it.categories + (response.categories ?: emptyList()),
+                            currentPage = page,
+                            totalPages = total,
+                            hasMore = page < total,
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update { it.copy(isLoadingMore = false, error = t.message) }
+                }
+        }
+    }
+
+    private fun currentSearch(): String? = _state.value.searchQuery.trim().ifBlank { null }
+
+    class Factory(
+        private val categoryRepository: HabitCategoryRepository,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(CategoriesViewModel::class.java))
+            return CategoriesViewModel(categoryRepository) as T
+        }
+    }
+
+    private companion object {
+        const val SEARCH_DEBOUNCE_MS = 400L
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
@@ -77,6 +78,7 @@ private val OrangeFire = Color(0xFFF59E0B)
 fun HomeScreen(
     viewModel: HomeViewModel,
     onLoggedOut: () -> Unit,
+    onOpenCategories: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -120,7 +122,7 @@ fun HomeScreen(
             ),
         ) {
             item {
-                HomeHeader(onLoggedOut = onLoggedOut)
+                HomeHeader(onLoggedOut = onLoggedOut, onOpenCategories = onOpenCategories)
                 Spacer(Modifier.height(10.dp))
                 StatsRow()
                 Spacer(Modifier.height(20.dp))
@@ -210,7 +212,7 @@ fun HomeScreen(
 }
 
 @Composable
-private fun HomeHeader(onLoggedOut: () -> Unit) {
+private fun HomeHeader(onLoggedOut: () -> Unit, onOpenCategories: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -235,13 +237,23 @@ private fun HomeHeader(onLoggedOut: () -> Unit) {
             },
             fontSize = 22.sp,
         )
-        IconButton(
-            onClick = onLoggedOut,
-            modifier = Modifier
-                .background(DarkSurfaceVariant, RoundedCornerShape(14.dp))
-                .size(46.dp),
-        ) {
-            Icon(Icons.Filled.Person, contentDescription = "Perfil / Cerrar sesión", tint = DarkOnBackground)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            IconButton(
+                onClick = onOpenCategories,
+                modifier = Modifier
+                    .background(DarkSurfaceVariant, RoundedCornerShape(14.dp))
+                    .size(46.dp),
+            ) {
+                Icon(Icons.Filled.Category, contentDescription = "Categorías", tint = DarkOnBackground)
+            }
+            IconButton(
+                onClick = onLoggedOut,
+                modifier = Modifier
+                    .background(DarkSurfaceVariant, RoundedCornerShape(14.dp))
+                    .size(46.dp),
+            ) {
+                Icon(Icons.Filled.Person, contentDescription = "Perfil / Cerrar sesión", tint = DarkOnBackground)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -10,12 +10,15 @@ import androidx.navigation.compose.rememberNavController
 import com.example.leveluplife.AppContainer
 import com.example.leveluplife.ui.auth.LoginScreen
 import com.example.leveluplife.ui.auth.LoginViewModel
+import com.example.leveluplife.ui.categories.CategoriesScreen
+import com.example.leveluplife.ui.categories.CategoriesViewModel
 import com.example.leveluplife.ui.home.HomeScreen
 import com.example.leveluplife.ui.home.HomeViewModel
 
 object Routes {
     const val LOGIN = "login"
     const val DASHBOARD = "dashboard"
+    const val CATEGORIES = "categories"
 }
 
 @Composable
@@ -65,6 +68,23 @@ fun AppNavigation(
                         popUpTo(Routes.DASHBOARD) { inclusive = true }
                         launchSingleTop = true
                     }
+                },
+                onOpenCategories = {
+                    navController.navigate(Routes.CATEGORIES) {
+                        launchSingleTop = true
+                    }
+                },
+            )
+        }
+        composable(Routes.CATEGORIES) {
+            val vm: CategoriesViewModel = viewModel(
+                factory = CategoriesViewModel.Factory(container.habitCategoryRepository),
+            )
+            CategoriesScreen(
+                viewModel = vm,
+                onBack = { navController.popBackStack() },
+                onCategoryClick = {
+                    // Navegación al detalle de categoría: fuera de alcance de esta tarea.
                 },
             )
         }

--- a/app/src/test/java/com/example/leveluplife/data/auth/FakeTokenStore.kt
+++ b/app/src/test/java/com/example/leveluplife/data/auth/FakeTokenStore.kt
@@ -3,22 +3,26 @@ package com.example.leveluplife.data.auth
 internal class FakeTokenStore : TokenStore {
     private var access: String? = null
     private var refresh: String? = null
+    private var user: String? = null
 
     var saveCallCount = 0
     var clearCallCount = 0
 
-    override fun saveTokens(accessToken: String, refreshToken: String?) {
+    override fun saveTokens(accessToken: String, refreshToken: String?, userId: String?) {
         saveCallCount++
         access = accessToken
         refresh = refreshToken
+        user = userId
     }
 
     override fun accessToken(): String? = access
     override fun refreshToken(): String? = refresh
+    override fun userId(): String? = user
 
     override fun clear() {
         clearCallCount++
         access = null
         refresh = null
+        user = null
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Adds the habit categories index: a new screen that lists categories with search, infinite-scroll pagination, and cards showing name, description, image and the count of the user's habits in each category. Includes the data layer (DTO, Retrofit API, repository) and an entry point from the Home header.

---

## 🎯 Purpose

Implements the user story "As a user, I want to browse categories so I can find groups of habits that match my interests." It gives users a way to explore the available habit categories and see, per category, how many habits they personally have.

---

## 🔄 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:
- `:app:testDebugUnitTest` passes.
- Manually verified on device/emulator: categories load and render as cards with name, description, image placeholder and habit-count badge; the search box filters results (debounced, hitting `?search=`); infinite scroll loads more pages.
- Had to fix `FakeTokenStore` (test double) to match the updated `TokenStore` interface (`userId()` / `saveTokens(..., userId)`), otherwise the test module didn't compile.

---

## 📸 Screenshots (if applicable)

<img width="295" height="528" alt="image" src="https://github.com/user-attachments/assets/c04476d8-2420-4969-9123-f4c994acf32f" />

<img width="335" height="572" alt="image" src="https://github.com/user-attachments/assets/9c85fd12-7c82-4a99-a170-2772b6f5a899" />

<img width="377" height="533" alt="image" src="https://github.com/user-attachments/assets/66e12d3d-0c04-455b-8826-097f3062773c" />

---

## 🚀 Deployment Notes (if needed)

- Requires the matching backend change (search + per-user `habitsCount`) to be deployed.
- Images use a placeholder (category initial) until the backend exposes `imageUrl`.

---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #12
