### PR TITLE
feat(#6): add account deactivation flow with confirmation dialog

### DIFF
--- a/app/src/main/java/com/example/leveluplife/AppContainer.kt
+++ b/app/src/main/java/com/example/leveluplife/AppContainer.kt
@@ -11,6 +11,9 @@ import com.example.leveluplife.data.network.AuthApi
 import com.example.leveluplife.data.network.HabitsApi
 import com.example.leveluplife.data.network.HostProvider
 import com.example.leveluplife.data.network.NetworkModule
+import com.example.leveluplife.data.network.PlayerApi
+import com.example.leveluplife.data.player.DefaultPlayerRepository
+import com.example.leveluplife.data.player.PlayerRepository
 import com.example.leveluplife.data.preferences.DebugApiPreferences
 import com.example.leveluplife.data.preferences.ThemePreferences
 import com.example.leveluplife.ui.theme.ThemeController
@@ -37,6 +40,7 @@ class AppContainer(applicationContext: Context) {
     }
     private val authApi: AuthApi by lazy { NetworkModule.provideAuthApi(retrofit) }
     private val habitsApi: HabitsApi by lazy { NetworkModule.provideHabitsApi(retrofit) }
+    private val playerApi: PlayerApi by lazy { NetworkModule.providePlayerApi(retrofit) }
 
     val authRepository: AuthRepository by lazy {
         DefaultAuthRepository(
@@ -48,5 +52,9 @@ class AppContainer(applicationContext: Context) {
 
     val habitRepository: HabitRepository by lazy {
         DefaultHabitRepository(api = habitsApi)
+    }
+
+    val playerRepository: PlayerRepository by lazy {
+        DefaultPlayerRepository(api = playerApi, tokenStore = tokenStore)
     }
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/NetworkModule.kt
@@ -51,5 +51,7 @@ object NetworkModule {
 
     fun provideHabitsApi(retrofit: Retrofit): HabitsApi = retrofit.create(HabitsApi::class.java)
 
+    fun providePlayerApi(retrofit: Retrofit): PlayerApi = retrofit.create(PlayerApi::class.java)
+
     fun jsonParser(): Json = json
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/PlayerApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/PlayerApi.kt
@@ -1,0 +1,14 @@
+package com.example.leveluplife.data.network
+
+import com.example.leveluplife.data.network.dto.DeletePlayerAccountRequest
+import com.example.leveluplife.data.network.dto.DeletePlayerAccountResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.PATCH
+
+interface PlayerApi {
+    @PATCH("api/player/delete")
+    suspend fun deactivateAccount(
+        @Body body: DeletePlayerAccountRequest? = null,
+    ): Response<DeletePlayerAccountResponse>
+}

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/PlayerDtos.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/PlayerDtos.kt
@@ -1,0 +1,15 @@
+package com.example.leveluplife.data.network.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeletePlayerAccountRequest(
+    val reason: String? = null,
+)
+
+@Serializable
+data class DeletePlayerAccountResponse(
+    val success: Boolean = false,
+    val message: String = "",
+    val deactivatedAt: String = "",
+)

--- a/app/src/main/java/com/example/leveluplife/data/player/PlayerRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/PlayerRepository.kt
@@ -1,0 +1,94 @@
+package com.example.leveluplife.data.player
+
+import com.example.leveluplife.data.auth.TokenStore
+import com.example.leveluplife.data.network.PlayerApi
+import com.example.leveluplife.data.network.dto.DeletePlayerAccountRequest
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+data class DeactivateAccountResult(
+    val message: String,
+    val deactivatedAt: String,
+)
+
+sealed class DeactivateAccountError(open val message: String) {
+    data class Unauthorized(override val message: String) : DeactivateAccountError(message)
+    data class Forbidden(override val message: String) : DeactivateAccountError(message)
+    data class NotFound(override val message: String) : DeactivateAccountError(message)
+    data class Server(override val message: String) : DeactivateAccountError(message)
+    data class Network(override val message: String) : DeactivateAccountError(message)
+    data class Unknown(override val message: String) : DeactivateAccountError(message)
+}
+
+class DeactivateAccountException(val error: DeactivateAccountError) :
+    Exception(error.message)
+
+interface PlayerRepository {
+    suspend fun deactivateAccount(reason: String? = null): Result<DeactivateAccountResult>
+}
+
+class DefaultPlayerRepository(
+    private val api: PlayerApi,
+    private val tokenStore: TokenStore,
+) : PlayerRepository {
+
+    override suspend fun deactivateAccount(reason: String?): Result<DeactivateAccountResult> = try {
+        val trimmedReason = reason?.trim()?.takeIf { it.isNotEmpty() }
+        val response = api.deactivateAccount(
+            DeletePlayerAccountRequest(reason = trimmedReason),
+        )
+        when {
+            response.isSuccessful -> {
+                val body = response.body()
+                tokenStore.clear()
+                Result.success(
+                    DeactivateAccountResult(
+                        message = body?.message?.ifBlank { null }
+                            ?: "Cuenta desactivada correctamente",
+                        deactivatedAt = body?.deactivatedAt.orEmpty(),
+                    ),
+                )
+            }
+            response.code() == 401 -> Result.failure(
+                DeactivateAccountException(
+                    DeactivateAccountError.Unauthorized("Sesión expirada. Volvé a iniciar sesión."),
+                ),
+            )
+            response.code() == 403 -> Result.failure(
+                DeactivateAccountException(
+                    DeactivateAccountError.Forbidden(
+                        "No tenés permiso para desactivar esta cuenta o ya está inactiva.",
+                    ),
+                ),
+            )
+            response.code() == 404 -> Result.failure(
+                DeactivateAccountException(
+                    DeactivateAccountError.NotFound("No se encontró tu cuenta."),
+                ),
+            )
+            response.code() in 500..599 -> Result.failure(
+                DeactivateAccountException(
+                    DeactivateAccountError.Server("Error del servidor. Intentá más tarde."),
+                ),
+            )
+            else -> Result.failure(
+                DeactivateAccountException(
+                    DeactivateAccountError.Unknown("No se pudo desactivar la cuenta (HTTP ${response.code()})."),
+                ),
+            )
+        }
+    } catch (e: SocketTimeoutException) {
+        Result.failure(DeactivateAccountException(DeactivateAccountError.Network("timeout")))
+    } catch (e: UnknownHostException) {
+        Result.failure(DeactivateAccountException(DeactivateAccountError.Network("unknown_host")))
+    } catch (e: IOException) {
+        Result.failure(DeactivateAccountException(DeactivateAccountError.Network(e.message ?: "network")))
+    } catch (t: Throwable) {
+        Result.failure(
+            DeactivateAccountException(
+                DeactivateAccountError.Unknown(t.message ?: "Error inesperado"),
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/auth/LoginScreen.kt
@@ -80,9 +80,12 @@ fun LoginScreen(
     themeController: ThemeController,
     onLoggedIn: () -> Unit,
     onNavigateToRegister: () -> Unit,
+    infoMessage: String? = null,
+    onInfoMessageShown: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
 
     LaunchedEffect(state.loggedInUser) {
         if (state.loggedInUser != null) {
@@ -91,17 +94,30 @@ fun LoginScreen(
         }
     }
 
-    LoginContent(
-        state = state,
-        themeController = themeController,
-        onEmailChange = viewModel::onEmailChange,
-        onPasswordChange = viewModel::onPasswordChange,
-        onTogglePasswordVisibility = viewModel::onTogglePasswordVisibility,
-        onSubmit = viewModel::onSubmit,
-        onDismissError = viewModel::dismissError,
-        onNavigateToRegister = onNavigateToRegister,
+    LaunchedEffect(infoMessage) {
+        if (!infoMessage.isNullOrBlank()) {
+            snackbarHostState.showSnackbar(infoMessage)
+            onInfoMessageShown()
+        }
+    }
+
+    androidx.compose.material3.Scaffold(
+        snackbarHost = { androidx.compose.material3.SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
         modifier = modifier,
-    )
+    ) { innerPadding ->
+        LoginContent(
+            state = state,
+            themeController = themeController,
+            onEmailChange = viewModel::onEmailChange,
+            onPasswordChange = viewModel::onPasswordChange,
+            onTogglePasswordVisibility = viewModel::onTogglePasswordVisibility,
+            onSubmit = viewModel::onSubmit,
+            onDismissError = viewModel::dismissError,
+            onNavigateToRegister = onNavigateToRegister,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/example/leveluplife/ui/components/LulConfirmAlertDialog.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/components/LulConfirmAlertDialog.kt
@@ -1,0 +1,50 @@
+package com.example.leveluplife.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+fun LulConfirmAlertDialog(
+    title: String,
+    message: String,
+    confirmText: String,
+    dismissText: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    titleTextStyle: TextStyle = MaterialTheme.typography.titleLarge,
+    messageTextStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    confirmEnabled: Boolean = true,
+    confirmTestTag: String? = null,
+    dismissTestTag: String? = null,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(text = title, style = titleTextStyle) },
+        text = { Text(text = message, style = messageTextStyle) },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = if (dismissTestTag != null) Modifier.testTag(dismissTestTag) else Modifier,
+            ) {
+                Text(text = dismissText)
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                enabled = confirmEnabled,
+                modifier = if (confirmTestTag != null) Modifier.testTag(confirmTestTag) else Modifier,
+            ) {
+                Text(text = confirmText)
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
@@ -77,6 +77,7 @@ private val OrangeFire = Color(0xFFF59E0B)
 fun HomeScreen(
     viewModel: HomeViewModel,
     onLoggedOut: () -> Unit,
+    onOpenSettings: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -107,7 +108,7 @@ fun HomeScreen(
                 Icon(Icons.Filled.Add, contentDescription = "Agregar misión")
             }
         },
-        bottomBar = { HomeBottomBar() },
+        bottomBar = { HomeBottomBar(onOpenSettings = onOpenSettings) },
     ) { innerPadding ->
         LazyColumn(
             state = listState,
@@ -441,15 +442,20 @@ private fun HabitCard(habit: HabitDto) {
     }
 }
 
-private data class NavItem(val label: String, val icon: ImageVector, val selected: Boolean)
+private data class NavItem(
+    val label: String,
+    val icon: ImageVector,
+    val selected: Boolean,
+    val onClick: () -> Unit = {},
+)
 
 @Composable
-private fun HomeBottomBar() {
+private fun HomeBottomBar(onOpenSettings: () -> Unit) {
     val items = listOf(
-        NavItem("INICIO", Icons.Filled.Home, true),
-        NavItem("COACH", Icons.Filled.Chat, false),
-        NavItem("TIENDA", Icons.Filled.ShoppingBag, false),
-        NavItem("AJUSTES", Icons.Filled.Settings, false),
+        NavItem("INICIO", Icons.Filled.Home, true, onClick = {}),
+        NavItem("COACH", Icons.Filled.Chat, false, onClick = {}),
+        NavItem("TIENDA", Icons.Filled.ShoppingBag, false, onClick = {}),
+        NavItem("AJUSTES", Icons.Filled.Settings, false, onClick = onOpenSettings),
     )
     NavigationBar(
         containerColor = DarkSurface,
@@ -458,7 +464,7 @@ private fun HomeBottomBar() {
         items.forEach { item ->
             NavigationBarItem(
                 selected = item.selected,
-                onClick = {},
+                onClick = item.onClick,
                 icon = { Icon(item.icon, contentDescription = item.label) },
                 label = {
                     Text(

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -12,10 +12,15 @@ import com.example.leveluplife.ui.auth.LoginScreen
 import com.example.leveluplife.ui.auth.LoginViewModel
 import com.example.leveluplife.ui.home.HomeScreen
 import com.example.leveluplife.ui.home.HomeViewModel
+import com.example.leveluplife.ui.settings.SettingsScreen
+import com.example.leveluplife.ui.settings.SettingsViewModel
 
 object Routes {
     const val LOGIN = "login"
     const val DASHBOARD = "dashboard"
+    const val SETTINGS = "settings"
+
+    const val ARG_DEACTIVATION_MESSAGE = "deactivation_message"
 }
 
 @Composable
@@ -35,22 +40,26 @@ fun AppNavigation(
         startDestination = startDestination,
         modifier = modifier,
     ) {
-        composable(Routes.LOGIN) {
+        composable(Routes.LOGIN) { backStackEntry ->
+            val deactivationMessage = backStackEntry.savedStateHandle
+                .get<String>(Routes.ARG_DEACTIVATION_MESSAGE)
             val vm: LoginViewModel = viewModel(
                 factory = LoginViewModel.Factory(container.authRepository),
             )
             LoginScreen(
                 viewModel = vm,
                 themeController = container.themeController,
+                infoMessage = deactivationMessage,
+                onInfoMessageShown = {
+                    backStackEntry.savedStateHandle.remove<String>(Routes.ARG_DEACTIVATION_MESSAGE)
+                },
                 onLoggedIn = {
                     navController.navigate(Routes.DASHBOARD) {
                         popUpTo(Routes.LOGIN) { inclusive = true }
                         launchSingleTop = true
                     }
                 },
-                onNavigateToRegister = {
-                    // Registro fuera de alcance de esta tarea.
-                },
+                onNavigateToRegister = {},
             )
         }
         composable(Routes.DASHBOARD) {
@@ -64,6 +73,30 @@ fun AppNavigation(
                     navController.navigate(Routes.LOGIN) {
                         popUpTo(Routes.DASHBOARD) { inclusive = true }
                         launchSingleTop = true
+                    }
+                },
+                onOpenSettings = {
+                    navController.navigate(Routes.SETTINGS)
+                },
+            )
+        }
+        composable(Routes.SETTINGS) {
+            val vm: SettingsViewModel = viewModel(
+                factory = SettingsViewModel.Factory(container.playerRepository),
+            )
+            SettingsScreen(
+                viewModel = vm,
+                onBack = { navController.popBackStack() },
+                onAccountDeactivated = { message ->
+                    container.authRepository.logout()
+                    navController.navigate(Routes.LOGIN) {
+                        popUpTo(Routes.DASHBOARD) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                    runCatching {
+                        navController.getBackStackEntry(Routes.LOGIN)
+                            .savedStateHandle
+                            .set(Routes.ARG_DEACTIVATION_MESSAGE, message)
                     }
                 },
             )

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -119,7 +119,6 @@ fun AppNavigation(
                 viewModel = vm,
                 onBack = { navController.popBackStack() },
                 onAccountDeactivated = { message ->
-                    container.authRepository.logout()
                     navController.navigate(Routes.LOGIN) {
                         popUpTo(Routes.DASHBOARD) { inclusive = true }
                         launchSingleTop = true

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -3,7 +3,9 @@ package com.example.leveluplife.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.leveluplife.R
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -25,6 +27,7 @@ object Routes {
     const val SETTINGS = "settings"
 
     const val ARG_DEACTIVATION_MESSAGE = "deactivation_message"
+    const val ARG_SESSION_EXPIRED_MESSAGE = "session_expired_message"
 }
 
 @Composable
@@ -39,12 +42,19 @@ fun AppNavigation(
         Routes.LOGIN
     }
 
-    LaunchedEffect(container.sessionEvents) {
+    val sessionExpiredMessage = stringResource(R.string.login_session_expired_redirect)
+
+    LaunchedEffect(container.sessionEvents, sessionExpiredMessage) {
         container.sessionEvents.expired.collect {
             container.authRepository.logout()
             navController.navigate(Routes.LOGIN) {
                 popUpTo(Routes.DASHBOARD) { inclusive = true }
                 launchSingleTop = true
+            }
+            runCatching {
+                navController.getBackStackEntry(Routes.LOGIN)
+                    .savedStateHandle
+                    .set(Routes.ARG_SESSION_EXPIRED_MESSAGE, sessionExpiredMessage)
             }
         }
     }
@@ -55,17 +65,20 @@ fun AppNavigation(
         modifier = modifier,
     ) {
         composable(Routes.LOGIN) { backStackEntry ->
-            val deactivationMessage = backStackEntry.savedStateHandle
+            val infoMessage = backStackEntry.savedStateHandle
                 .get<String>(Routes.ARG_DEACTIVATION_MESSAGE)
+                ?: backStackEntry.savedStateHandle
+                    .get<String>(Routes.ARG_SESSION_EXPIRED_MESSAGE)
             val vm: LoginViewModel = viewModel(
                 factory = LoginViewModel.Factory(container.authRepository),
             )
             LoginScreen(
                 viewModel = vm,
                 themeController = container.themeController,
-                infoMessage = deactivationMessage,
+                infoMessage = infoMessage,
                 onInfoMessageShown = {
                     backStackEntry.savedStateHandle.remove<String>(Routes.ARG_DEACTIVATION_MESSAGE)
+                    backStackEntry.savedStateHandle.remove<String>(Routes.ARG_SESSION_EXPIRED_MESSAGE)
                 },
                 onLoggedIn = {
                     navController.navigate(Routes.DASHBOARD) {

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileViewModel.kt
@@ -123,7 +123,7 @@ class ProfileViewModel(
     }
 
     fun onAvatarSelected(uri: String, mimeType: String?, sizeBytes: Long) {
-        when (AvatarValidator.validate(mimeType, sizeBytes)) {
+        when (val validationError = AvatarValidator.validate(mimeType, sizeBytes)) {
             null -> {
                 viewModelScope.launch {
                     val persistedUri = avatarStorage.persistFromPickerUri(uri, mimeType)
@@ -142,11 +142,8 @@ class ProfileViewModel(
                     profileCache.updateLocalExtras(persistedUri, _state.value.bio)
                 }
             }
-            AvatarValidationError.TooLarge -> {
-                _state.update { it.copy(avatarError = AvatarValidationError.TooLarge) }
-            }
-            AvatarValidationError.UnsupportedType -> {
-                _state.update { it.copy(avatarError = AvatarValidationError.UnsupportedType) }
+            else -> {
+                _state.update { it.copy(avatarError = validationError) }
             }
         }
     }

--- a/app/src/main/java/com/example/leveluplife/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/settings/SettingsScreen.kt
@@ -1,0 +1,294 @@
+package com.example.leveluplife.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.leveluplife.R
+import com.example.leveluplife.ui.components.LulErrorAlertDialog
+import com.example.leveluplife.ui.components.LulPrimaryButton
+import com.example.leveluplife.ui.theme.DarkBackground
+import com.example.leveluplife.ui.theme.DarkOnBackground
+import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
+import com.example.leveluplife.ui.theme.DarkSurface
+import com.example.leveluplife.ui.theme.DarkSurfaceVariant
+import com.example.leveluplife.ui.theme.PurplePrimary
+import com.example.leveluplife.ui.theme.PurplePrimaryContainer
+
+object SettingsTestTags {
+    const val DEACTIVATE_BUTTON = "settings_deactivate_button"
+    const val CONFIRM_DIALOG = "settings_confirm_dialog"
+    const val CANCEL_BUTTON = "settings_cancel_button"
+    const val CONFIRM_DEACTIVATE_BUTTON = "settings_confirm_deactivate_button"
+}
+
+private val DangerRed = Color(0xFFEF4444)
+
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onAccountDeactivated: (message: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+    val defaultDeactivationMessage = stringResource(R.string.settings_deactivate_success)
+
+    LaunchedEffect(state.accountDeactivated, defaultDeactivationMessage) {
+        if (state.accountDeactivated) {
+            val message = state.deactivationMessage ?: defaultDeactivationMessage
+            onAccountDeactivated(message)
+            viewModel.consumeDeactivatedEvent()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = DarkBackground,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.settings_back),
+                        tint = DarkOnBackground,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = DarkOnBackground,
+                )
+            }
+
+            ConsequencesCard()
+
+            RecoveryInfoCard()
+
+            Spacer(Modifier.height(8.dp))
+
+            LulPrimaryButton(
+                text = stringResource(R.string.settings_deactivate_button),
+                onClick = viewModel::onRequestDeactivate,
+                modifier = Modifier.testTag(SettingsTestTags.DEACTIVATE_BUTTON),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = DangerRed,
+                    contentColor = Color.White,
+                    disabledContainerColor = DangerRed.copy(alpha = 0.5f),
+                ),
+                trailingIcon = Icons.Outlined.WarningAmber,
+            )
+        }
+    }
+
+    if (state.showConfirmDialog) {
+        DeactivateConfirmDialog(
+            state = state,
+            onDismiss = viewModel::onCancelDeactivate,
+            onConfirm = viewModel::confirmDeactivate,
+            onAcknowledgedChange = viewModel::onConsequencesAcknowledgedChange,
+            onReasonChange = viewModel::onReasonChange,
+        )
+    }
+
+    if (state.errorMessage != null) {
+        LulErrorAlertDialog(
+            title = stringResource(R.string.error_dialog_title),
+            message = state.errorMessage ?: "",
+            dismissText = stringResource(R.string.login_dismiss),
+            onDismiss = viewModel::dismissError,
+            errorTestTag = SettingsTestTags.CONFIRM_DIALOG,
+        )
+    }
+}
+
+@Composable
+private fun ConsequencesCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = DarkSurface),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_deactivate_section_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = DarkOnBackground,
+            )
+            Text(
+                text = stringResource(R.string.settings_deactivate_consequences),
+                style = MaterialTheme.typography.bodyMedium,
+                color = DarkOnSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecoveryInfoCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = PurplePrimaryContainer.copy(alpha = 0.35f)),
+        border = CardDefaults.outlinedCardBorder(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                Icons.Outlined.Info,
+                contentDescription = null,
+                tint = PurplePrimary,
+            )
+            Text(
+                text = stringResource(R.string.settings_reactivation_info),
+                style = MaterialTheme.typography.bodySmall,
+                color = DarkOnBackground,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DeactivateConfirmDialog(
+    state: SettingsUiState,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    onAcknowledgedChange: (Boolean) -> Unit,
+    onReasonChange: (String) -> Unit,
+) {
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = PurplePrimary,
+        unfocusedBorderColor = DarkSurfaceVariant,
+        focusedTextColor = DarkOnBackground,
+        unfocusedTextColor = DarkOnBackground,
+        cursorColor = PurplePrimary,
+    )
+
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag(SettingsTestTags.CONFIRM_DIALOG),
+        icon = {
+            Icon(Icons.Outlined.WarningAmber, contentDescription = null, tint = DangerRed)
+        },
+        title = {
+            Text(stringResource(R.string.settings_confirm_title))
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(stringResource(R.string.settings_confirm_message))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Checkbox(
+                        checked = state.consequencesAcknowledged,
+                        onCheckedChange = onAcknowledgedChange,
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = PurplePrimary,
+                            uncheckedColor = DarkOnSurfaceVariant,
+                        ),
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_confirm_acknowledge),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = DarkOnBackground,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                OutlinedTextField(
+                    value = state.reason,
+                    onValueChange = onReasonChange,
+                    label = { Text(stringResource(R.string.settings_deactivate_reason_label)) },
+                    placeholder = { Text(stringResource(R.string.settings_deactivate_reason_hint)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    maxLines = 3,
+                    colors = fieldColors,
+                    enabled = !state.isDeactivating,
+                )
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(
+                onClick = onDismiss,
+                enabled = !state.isDeactivating,
+                modifier = Modifier.testTag(SettingsTestTags.CANCEL_BUTTON),
+            ) {
+                Text(stringResource(R.string.settings_cancel))
+            }
+        },
+        confirmButton = {
+            androidx.compose.material3.TextButton(
+                onClick = onConfirm,
+                enabled = state.consequencesAcknowledged && !state.isDeactivating,
+                modifier = Modifier.testTag(SettingsTestTags.CONFIRM_DEACTIVATE_BUTTON),
+            ) {
+                Text(
+                    text = if (state.isDeactivating) {
+                        stringResource(R.string.settings_deactivating)
+                    } else {
+                        stringResource(R.string.settings_confirm_deactivate)
+                    },
+                    color = DangerRed,
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/example/leveluplife/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/settings/SettingsUiState.kt
@@ -1,0 +1,11 @@
+package com.example.leveluplife.ui.settings
+
+data class SettingsUiState(
+    val showConfirmDialog: Boolean = false,
+    val consequencesAcknowledged: Boolean = false,
+    val reason: String = "",
+    val isDeactivating: Boolean = false,
+    val errorMessage: String? = null,
+    val accountDeactivated: Boolean = false,
+    val deactivationMessage: String? = null,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,113 @@
+package com.example.leveluplife.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.leveluplife.data.player.DeactivateAccountException
+import com.example.leveluplife.data.player.PlayerRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+class SettingsViewModel(
+    private val playerRepository: PlayerRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SettingsUiState())
+    val state: StateFlow<SettingsUiState> = _state.asStateFlow()
+
+    fun onRequestDeactivate() {
+        _state.update {
+            it.copy(
+                showConfirmDialog = true,
+                consequencesAcknowledged = false,
+                reason = "",
+                errorMessage = null,
+            )
+        }
+    }
+
+    fun onCancelDeactivate() {
+        _state.update {
+            it.copy(
+                showConfirmDialog = false,
+                consequencesAcknowledged = false,
+                reason = "",
+                errorMessage = null,
+            )
+        }
+    }
+
+    fun onConsequencesAcknowledgedChange(value: Boolean) {
+        _state.update { it.copy(consequencesAcknowledged = value) }
+    }
+
+    fun onReasonChange(value: String) {
+        _state.update { it.copy(reason = value.take(200)) }
+    }
+
+    fun dismissError() {
+        _state.update { it.copy(errorMessage = null) }
+    }
+
+    fun consumeDeactivatedEvent() {
+        _state.update { it.copy(accountDeactivated = false, deactivationMessage = null) }
+    }
+
+    fun confirmDeactivate() {
+        val current = _state.value
+        if (!current.consequencesAcknowledged || current.isDeactivating) return
+
+        viewModelScope.launch {
+            _state.update {
+                it.copy(isDeactivating = true, errorMessage = null)
+            }
+            playerRepository.deactivateAccount(current.reason)
+                .onSuccess { result ->
+                    _state.update {
+                        it.copy(
+                            isDeactivating = false,
+                            showConfirmDialog = false,
+                            accountDeactivated = true,
+                            deactivationMessage = result.message,
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update {
+                        it.copy(
+                            isDeactivating = false,
+                            errorMessage = mapError(t),
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun mapError(t: Throwable): String = when (t) {
+        is DeactivateAccountException -> when (val err = t.error) {
+            is com.example.leveluplife.data.player.DeactivateAccountError.Network ->
+                if (err.message == "timeout" || err.message == "unknown_host") {
+                    "Sin conexión. Revisá tu red e intentá de nuevo."
+                } else {
+                    "Sin conexión. Revisá tu red e intentá de nuevo."
+                }
+            else -> err.message
+        }
+        is IOException -> "Sin conexión. Revisá tu red e intentá de nuevo."
+        else -> t.message ?: "No se pudo desactivar la cuenta."
+    }
+
+    class Factory(
+        private val playerRepository: PlayerRepository,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(SettingsViewModel::class.java))
+            return SettingsViewModel(playerRepository) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.example.leveluplife.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.example.leveluplife.data.player.DeactivateAccountError
 import com.example.leveluplife.data.player.DeactivateAccountException
 import com.example.leveluplife.data.player.PlayerRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -89,16 +90,15 @@ class SettingsViewModel(
 
     private fun mapError(t: Throwable): String = when (t) {
         is DeactivateAccountException -> when (val err = t.error) {
-            is com.example.leveluplife.data.player.DeactivateAccountError.Network ->
-                if (err.message == "timeout" || err.message == "unknown_host") {
-                    "Sin conexión. Revisá tu red e intentá de nuevo."
-                } else {
-                    "Sin conexión. Revisá tu red e intentá de nuevo."
-                }
+            is DeactivateAccountError.Network -> NETWORK_ERROR_MESSAGE
             else -> err.message
         }
-        is IOException -> "Sin conexión. Revisá tu red e intentá de nuevo."
+        is IOException -> NETWORK_ERROR_MESSAGE
         else -> t.message ?: "No se pudo desactivar la cuenta."
+    }
+
+    private companion object {
+        const val NETWORK_ERROR_MESSAGE = "Sin conexión. Revisá tu red e intentá de nuevo."
     }
 
     class Factory(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,21 @@
     <string name="dashboard_subtitle">Has iniciado sesión correctamente.</string>
     <string name="dashboard_session_active">Sesión activa</string>
     <string name="dashboard_logout">Cerrar sesión</string>
+
+    <!-- Settings / deactivate account -->
+    <string name="settings_title">Ajustes</string>
+    <string name="settings_back">Volver</string>
+    <string name="settings_deactivate_section_title">Desactivar cuenta</string>
+    <string name="settings_deactivate_consequences">Al desactivar tu cuenta:\n\n• No podrás iniciar sesión de nuevo.\n• Tu progreso y hábitos quedarán inactivos.\n• Se cerrará la sesión en este dispositivo.\n• Se borrarán los datos locales de la app.</string>
+    <string name="settings_reactivation_info">La reactivación no está disponible desde la app. Si necesitás recuperar tu cuenta, contactá al equipo de soporte.</string>
+    <string name="settings_deactivate_button">Desactivar mi cuenta</string>
+    <string name="settings_confirm_title">¿Desactivar cuenta?</string>
+    <string name="settings_confirm_message">Esta acción desactiva tu cuenta de forma permanente desde la app. Confirmá solo si entendés las consecuencias.</string>
+    <string name="settings_confirm_acknowledge">Entiendo las consecuencias y quiero continuar</string>
+    <string name="settings_deactivate_reason_label">Motivo (opcional)</string>
+    <string name="settings_deactivate_reason_hint">Contanos por qué te vas…</string>
+    <string name="settings_cancel">Cancelar</string>
+    <string name="settings_confirm_deactivate">Desactivar</string>
+    <string name="settings_deactivating">Desactivando…</string>
+    <string name="settings_deactivate_success">Tu cuenta fue desactivada. La sesión local se cerró correctamente.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <!-- Login: errores -->
     <string name="login_error_invalid_credentials">Usuario/email o contraseña incorrectos</string>
     <string name="login_error_session_expired">Tu sesión expiró. Iniciá sesión de nuevo.</string>
+    <string name="login_session_expired_redirect">Tu sesión terminó y se cerró automáticamente. Iniciá sesión de nuevo para continuar.</string>
     <string name="login_error_account_locked">Tu cuenta está bloqueada. Intenta más tarde.</string>
     <string name="login_error_bad_request">Solicitud inválida. Revisa los datos ingresados.</string>
     <string name="login_error_server">Error del servidor. Intenta más tarde.</string>

--- a/app/src/test/java/com/example/leveluplife/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,116 @@
+package com.example.leveluplife.ui.settings
+
+import com.example.leveluplife.data.player.DeactivateAccountResult
+import com.example.leveluplife.data.player.PlayerRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `cancel deactivation closes dialog without API call`() = runTest(testDispatcher) {
+        val repo = FakePlayerRepository()
+        val vm = SettingsViewModel(repo)
+
+        vm.onRequestDeactivate()
+        vm.onCancelDeactivate()
+
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.showConfirmDialog)
+        assertEquals(0, repo.deactivateCalls)
+    }
+
+    @Test
+    fun `confirm without acknowledgement does not call repository`() = runTest(testDispatcher) {
+        val repo = FakePlayerRepository()
+        val vm = SettingsViewModel(repo)
+
+        vm.onRequestDeactivate()
+        vm.confirmDeactivate()
+
+        advanceUntilIdle()
+
+        assertEquals(0, repo.deactivateCalls)
+    }
+
+    @Test
+    fun `successful deactivation emits accountDeactivated event`() = runTest(testDispatcher) {
+        val repo = FakePlayerRepository(
+            result = Result.success(
+                DeactivateAccountResult(
+                    message = "Cuenta desactivada correctamente",
+                    deactivatedAt = "2026-05-29T00:00:00Z",
+                ),
+            ),
+        )
+        val vm = SettingsViewModel(repo)
+
+        vm.onRequestDeactivate()
+        vm.onConsequencesAcknowledgedChange(true)
+        vm.confirmDeactivate()
+
+        advanceUntilIdle()
+
+        assertEquals(1, repo.deactivateCalls)
+        assertTrue(vm.state.value.accountDeactivated)
+        assertEquals("Cuenta desactivada correctamente", vm.state.value.deactivationMessage)
+        assertFalse(vm.state.value.showConfirmDialog)
+    }
+
+    @Test
+    fun `failed deactivation shows error and keeps dialog open`() = runTest(testDispatcher) {
+        val repo = FakePlayerRepository(
+            result = Result.failure(Exception("Sin conexión")),
+        )
+        val vm = SettingsViewModel(repo)
+
+        vm.onRequestDeactivate()
+        vm.onConsequencesAcknowledgedChange(true)
+        vm.confirmDeactivate()
+
+        advanceUntilIdle()
+
+        assertEquals(1, repo.deactivateCalls)
+        assertFalse(vm.state.value.accountDeactivated)
+        assertTrue(vm.state.value.showConfirmDialog)
+        assertTrue(vm.state.value.errorMessage?.isNotBlank() == true)
+    }
+
+    private class FakePlayerRepository(
+        private val result: Result<DeactivateAccountResult> = Result.success(
+            DeactivateAccountResult("OK", ""),
+        ),
+    ) : PlayerRepository {
+        var deactivateCalls = 0
+
+        override suspend fun deactivateAccount(reason: String?): Result<DeactivateAccountResult> {
+            deactivateCalls++
+            return result
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements the frontend flow for **soft account deactivation** (Issue #6), integrating with the backend endpoint `PATCH /api/player/delete`.

Users can deactivate their account from a new **Settings** screen accessible from the Home **AJUSTES** tab. The flow includes a consequences summary, a mandatory confirmation dialog with an acknowledgment checkbox, an optional deactivation reason, API call, local session cleanup, logout redirect, and a snackbar on the Login screen confirming the action.

### Key changes

**Data layer**
- `PlayerApi` — `PATCH api/player/delete` with optional `{ reason }` body
- `PlayerDtos` — request/response DTOs
- `PlayerRepository` — deactivation logic and error mapping (network, 401, 403, 404, 5xx)

**UI / UX**
- `SettingsScreen` — consequences card, reactivation info notice, deactivate CTA
- `DeactivateConfirmDialog` — mandatory checkbox + optional reason field
- `SettingsViewModel` + `SettingsUiState` — dialog state, API call, error handling
- `LulConfirmAlertDialog` — reusable confirmation dialog component

**Navigation & session**
- New `settings` route in `AppNavigation`
- Home **AJUSTES** tab navigates to Settings
- On success: `tokenStore.clear()` → logout → Login with snackbar feedback
- Cancel closes dialog without calling the API

**Strings**
- Spanish copy for settings, confirmation dialog, and success message

---

## 🎯 Purpose

Players need a safe, intentional way to deactivate their account from the app. This PR closes the frontend gap for Issue #6 by:

- Explaining the consequences before deactivation
- Requiring explicit user acknowledgment before proceeding
- Calling the backend soft-delete endpoint
- Clearing local auth data and returning the user to Login
- Preventing re-login after deactivation (backend returns 401, shown as invalid credentials)

Reactivation is **not** available from the app (aligned with current backend behavior).

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

### Manual testing (physical device + local backend)

1. Logged in with test user `aarontest`
2. Opened **Home → AJUSTES**
3. Reviewed consequences and reactivation notice
4. Tapped **Desactivar mi cuenta**
5. Confirmed dialog with checkbox checked and optional reason ("Motivos personales")
6. Verified redirect to Login with success snackbar
7. Attempted login again with same credentials → **"Usuario/email o contraseña incorrectos"** (expected: account is inactive)

Also verified **Cancel** closes the dialog without API call.

### Unit tests

- `SettingsViewModelTest`
  - Cancel closes dialog without API call
  - Confirm blocked until checkbox is checked
  - Successful deactivation emits `accountDeactivated` event
  - Failed deactivation shows error and keeps dialog open

### Backend dependency

- Requires `LevelUpLife-Backend` running with `PATCH /api/player/delete`
- Tested against local backend on `http://<LAN_IP>:5147`

---

## 📸 Screenshots (if applicable)

| Step | Screen | Image |
|------|--------|------------|
| 1 | Settings — consequences + deactivate button | <img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/69fde668-8166-41ba-94a6-70251610985c" />|
| 2 | Confirmation dialog — checkbox + optional reason |<img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/f01cf865-e37d-403e-b6a5-5d6751291e64" />|
| 3 | Login — invalid credentials after deactivation |<img width="1080" height="2229" alt="image" src="https://github.com/user-attachments/assets/87740439-9fbb-4fc2-9a8e-47bcf1ed1f05" />|

---

## 🚀 Deployment Notes (if needed)

- No special deployment steps.
- `api.host` in `local.properties` is per-developer and **not** committed.
- For physical devices, backend must bind to `0.0.0.0` and the app must point to the PC's LAN IP.
- Account reactivation is not supported by the current backend API.

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #6
Linked to #8