### PR TITLE
feat(#5): add player profile edit flow with session expiry redirect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
 
     implementation(libs.kotlinx.coroutines.android)
 
+    implementation(libs.coil.compose)
+
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)

--- a/app/src/main/java/com/example/leveluplife/AppContainer.kt
+++ b/app/src/main/java/com/example/leveluplife/AppContainer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.example.leveluplife.data.auth.AuthRepository
 import com.example.leveluplife.data.auth.DefaultAuthRepository
 import com.example.leveluplife.data.auth.EncryptedTokenStore
+import com.example.leveluplife.data.auth.SessionEvents
 import com.example.leveluplife.data.auth.TokenStore
 import com.example.leveluplife.data.habits.DefaultHabitRepository
 import com.example.leveluplife.data.habits.HabitRepository
@@ -11,6 +12,13 @@ import com.example.leveluplife.data.network.AuthApi
 import com.example.leveluplife.data.network.HabitsApi
 import com.example.leveluplife.data.network.HostProvider
 import com.example.leveluplife.data.network.NetworkModule
+import com.example.leveluplife.data.network.PlayerApi
+import com.example.leveluplife.data.player.DefaultProfileCache
+import com.example.leveluplife.data.player.DefaultProfileRepository
+import com.example.leveluplife.data.player.LocalProfileAvatarStorage
+import com.example.leveluplife.data.player.ProfileAvatarStorage
+import com.example.leveluplife.data.player.ProfileCache
+import com.example.leveluplife.data.player.ProfileRepository
 import com.example.leveluplife.data.preferences.DebugApiPreferences
 import com.example.leveluplife.data.preferences.ThemePreferences
 import com.example.leveluplife.ui.theme.ThemeController
@@ -30,13 +38,21 @@ class AppContainer(applicationContext: Context) {
     val hostProvider: HostProvider = HostProvider(debugApiPreferences)
 
     val tokenStore: TokenStore = EncryptedTokenStore(appContext)
+    val sessionEvents: SessionEvents = SessionEvents()
 
-    private val okHttp = NetworkModule.provideOkHttp(tokenStore)
+    private val okHttp = NetworkModule.provideOkHttp(tokenStore, sessionEvents)
     private val retrofit by lazy {
         NetworkModule.provideRetrofit(okHttp, hostProvider.resolveBaseUrl())
     }
     private val authApi: AuthApi by lazy { NetworkModule.provideAuthApi(retrofit) }
     private val habitsApi: HabitsApi by lazy { NetworkModule.provideHabitsApi(retrofit) }
+    private val playerApi: PlayerApi by lazy { NetworkModule.providePlayerApi(retrofit) }
+
+    val profileAvatarStorage: ProfileAvatarStorage by lazy { LocalProfileAvatarStorage(appContext) }
+
+    val profileCache: ProfileCache by lazy {
+        DefaultProfileCache(appContext, profileAvatarStorage)
+    }
 
     val authRepository: AuthRepository by lazy {
         DefaultAuthRepository(
@@ -48,5 +64,13 @@ class AppContainer(applicationContext: Context) {
 
     val habitRepository: HabitRepository by lazy {
         DefaultHabitRepository(api = habitsApi)
+    }
+
+    val profileRepository: ProfileRepository by lazy {
+        DefaultProfileRepository(
+            api = playerApi,
+            profileCache = profileCache,
+            json = NetworkModule.jsonParser(),
+        )
     }
 }

--- a/app/src/main/java/com/example/leveluplife/data/auth/SessionEvents.kt
+++ b/app/src/main/java/com/example/leveluplife/data/auth/SessionEvents.kt
@@ -1,0 +1,14 @@
+package com.example.leveluplife.data.auth
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class SessionEvents {
+    private val _expired = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val expired: SharedFlow<Unit> = _expired.asSharedFlow()
+
+    fun notifyExpired() {
+        _expired.tryEmit(Unit)
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/data/network/ApiRoutes.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/ApiRoutes.kt
@@ -1,0 +1,8 @@
+package com.example.leveluplife.data.network
+
+object ApiRoutes {
+    const val AUTH_LOGIN = "api/auth/login"
+
+    fun isLoginRequest(encodedPath: String): Boolean =
+        encodedPath.trim('/').lowercase().endsWith(AUTH_LOGIN.lowercase())
+}

--- a/app/src/main/java/com/example/leveluplife/data/network/AuthApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/AuthApi.kt
@@ -7,6 +7,6 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthApi {
-    @POST("api/auth/login")
+    @POST(ApiRoutes.AUTH_LOGIN)
     suspend fun login(@Body body: LoginRequest): Response<LoginResponse>
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.example.leveluplife.data.network
 
 import com.example.leveluplife.BuildConfig
+import com.example.leveluplife.data.auth.SessionEvents
 import com.example.leveluplife.data.auth.TokenStore
 import com.example.leveluplife.data.network.interceptor.AuthInterceptor
 import com.example.leveluplife.data.network.interceptor.RetryInterceptor
@@ -24,7 +25,7 @@ object NetworkModule {
     //   RetryInterceptor  – retries transient 5xx / IOException
     //   AuthInterceptor   – re-reads token on every attempt (future-proof for refresh)
     //   HttpLoggingInterceptor – logs the final request including auth header
-    fun provideOkHttp(tokenStore: TokenStore): OkHttpClient {
+    fun provideOkHttp(tokenStore: TokenStore, sessionEvents: SessionEvents): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
             else HttpLoggingInterceptor.Level.NONE
@@ -34,7 +35,7 @@ object NetworkModule {
             .readTimeout(15, TimeUnit.SECONDS)
             .writeTimeout(15, TimeUnit.SECONDS)
             .addInterceptor(RetryInterceptor())
-            .addInterceptor(AuthInterceptor(tokenStore))
+            .addInterceptor(AuthInterceptor(tokenStore, sessionEvents))
             .addInterceptor(logging)
             .build()
     }
@@ -50,6 +51,8 @@ object NetworkModule {
     fun provideAuthApi(retrofit: Retrofit): AuthApi = retrofit.create(AuthApi::class.java)
 
     fun provideHabitsApi(retrofit: Retrofit): HabitsApi = retrofit.create(HabitsApi::class.java)
+
+    fun providePlayerApi(retrofit: Retrofit): PlayerApi = retrofit.create(PlayerApi::class.java)
 
     fun jsonParser(): Json = json
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/PlayerApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/PlayerApi.kt
@@ -1,0 +1,21 @@
+package com.example.leveluplife.data.network
+
+import com.example.leveluplife.data.network.dto.GetPlayerProfileResponseDto
+import com.example.leveluplife.data.network.dto.UpdatePlayerProfileRequestDto
+import com.example.leveluplife.data.network.dto.UpdatePlayerProfileResponseDto
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.PUT
+
+interface PlayerApi {
+    @GET("api/Player/profile")
+    suspend fun getProfile(): Response<GetPlayerProfileResponseDto>
+
+    @PUT("api/Player/update")
+    suspend fun updateProfile(
+        @Header("If-Match") ifMatch: String,
+        @Body body: UpdatePlayerProfileRequestDto,
+    ): Response<UpdatePlayerProfileResponseDto>
+}

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/PlayerProfileDtos.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/PlayerProfileDtos.kt
@@ -1,0 +1,86 @@
+package com.example.leveluplife.data.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetPlayerProfileResponseDto(
+    @SerialName("PlayerUserId") val playerUserId: String = "",
+    @SerialName("PlayerUserUserName") val playerUserUserName: String = "",
+    @SerialName("PlayerUserLevel") val playerUserLevel: Int = 0,
+    @SerialName("statusIsActive") val statusIsActive: Boolean = true,
+    @SerialName("PlayerUserLastLogin") val playerUserLastLogin: String? = null,
+    @SerialName("PersonData") val personData: GetPlayerProfilePersonDataDto = GetPlayerProfilePersonDataDto(),
+)
+
+@Serializable
+data class GetPlayerProfilePersonDataDto(
+    @SerialName("name") val name: String = "",
+    @SerialName("lastName") val lastName: String = "",
+    @SerialName("email") val email: String = "",
+    @SerialName("birthdate") val birthdate: String? = null,
+)
+
+@Serializable
+data class UpdatePlayerProfileRequestDto(
+    val personData: PersonUpdateRequestDto? = null,
+    val playerData: PlayerDataUpdateRequestDto? = null,
+)
+
+@Serializable
+data class PersonUpdateRequestDto(
+    val name: String? = null,
+    val lastName: String? = null,
+    val email: String? = null,
+    val birthdate: String? = null,
+)
+
+@Serializable
+data class PlayerDataUpdateRequestDto(
+    val userName: String? = null,
+    val preferredClassId: Int? = null,
+    val timezone: String? = null,
+)
+
+@Serializable
+data class UpdatePlayerProfileResponseDto(
+    val success: Boolean = false,
+    val message: String = "",
+    val player: PlayerProfileDto = PlayerProfileDto(),
+)
+
+@Serializable
+data class PlayerProfileDto(
+    val id: Int = 0,
+    val userName: String = "",
+    val level: Int = 0,
+    val isActive: Boolean = true,
+    val lastLogin: String? = null,
+    val classId: Int = 0,
+    val className: String = "",
+    val person: PersonProfileDto = PersonProfileDto(),
+)
+
+@Serializable
+data class PersonProfileDto(
+    val id: Int = 0,
+    val name: String = "",
+    val lastName: String = "",
+    val email: String = "",
+    val birthdate: String? = null,
+    val isActive: Boolean = true,
+)
+
+@Serializable
+data class ApiProblemDetailsDto(
+    val title: String? = null,
+    val status: Int? = null,
+    val errors: Map<String, List<String>>? = null,
+)
+
+@Serializable
+data class ApiErrorEnvelopeDto(
+    val code: Int? = null,
+    val message: String? = null,
+    val details: String? = null,
+)

--- a/app/src/main/java/com/example/leveluplife/data/network/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/interceptor/AuthInterceptor.kt
@@ -2,6 +2,7 @@ package com.example.leveluplife.data.network.interceptor
 
 import com.example.leveluplife.data.auth.SessionEvents
 import com.example.leveluplife.data.auth.TokenStore
+import com.example.leveluplife.data.network.ApiRoutes
 import okhttp3.Interceptor
 import okhttp3.Response
 
@@ -24,7 +25,7 @@ class AuthInterceptor(
             chain.request()
         }
         val response = chain.proceed(request)
-        if (response.code == 401 && !request.url.encodedPath.endsWith("/api/auth/login")) {
+        if (response.code == 401 && !ApiRoutes.isLoginRequest(request.url.encodedPath)) {
             tokenStore.clear()
             sessionEvents.notifyExpired()
         }

--- a/app/src/main/java/com/example/leveluplife/data/network/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/interceptor/AuthInterceptor.kt
@@ -1,10 +1,14 @@
 package com.example.leveluplife.data.network.interceptor
 
+import com.example.leveluplife.data.auth.SessionEvents
 import com.example.leveluplife.data.auth.TokenStore
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class AuthInterceptor(private val tokenStore: TokenStore) : Interceptor {
+class AuthInterceptor(
+    private val tokenStore: TokenStore,
+    private val sessionEvents: SessionEvents,
+) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val token = tokenStore.accessToken()
@@ -20,7 +24,10 @@ class AuthInterceptor(private val tokenStore: TokenStore) : Interceptor {
             chain.request()
         }
         val response = chain.proceed(request)
-        if (response.code == 401) tokenStore.clear()
+        if (response.code == 401 && !request.url.encodedPath.endsWith("/api/auth/login")) {
+            tokenStore.clear()
+            sessionEvents.notifyExpired()
+        }
         return response
     }
 }

--- a/app/src/main/java/com/example/leveluplife/data/player/PlayerProfile.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/PlayerProfile.kt
@@ -1,0 +1,20 @@
+package com.example.leveluplife.data.player
+
+data class PlayerProfile(
+    val playerUserId: String,
+    val userName: String,
+    val level: Int,
+    val classId: Int = 0,
+    val className: String = "",
+    val name: String,
+    val lastName: String,
+    val email: String,
+    val birthdate: String? = null,
+    val avatarUri: String? = null,
+    val bio: String = "",
+)
+
+data class ProfileFetchResult(
+    val profile: PlayerProfile,
+    val etag: String,
+)

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileAvatarStorage.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileAvatarStorage.kt
@@ -1,0 +1,74 @@
+package com.example.leveluplife.data.player
+
+import android.content.Context
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+
+interface ProfileAvatarStorage {
+    suspend fun persistFromPickerUri(sourceUri: String, mimeType: String?): String?
+    fun resolveDisplayUri(storedUri: String?): String?
+}
+
+class LocalProfileAvatarStorage(
+    context: Context,
+) : ProfileAvatarStorage {
+
+    private val appContext = context.applicationContext
+
+    override suspend fun persistFromPickerUri(sourceUri: String, mimeType: String?): String? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val extension = extensionFor(mimeType)
+                val target = avatarFile(extension)
+                deleteAllAvatarFiles()
+
+                appContext.contentResolver.openInputStream(Uri.parse(sourceUri))?.use { input ->
+                    target.outputStream().use { output -> input.copyTo(output) }
+                } ?: throw IOException("Cannot open source avatar stream.")
+
+                if (!target.exists() || target.length() <= 0L) {
+                    throw IOException("Avatar file was not written.")
+                }
+
+                target.toURI().toString()
+            }.getOrNull()
+        }
+
+    override fun resolveDisplayUri(storedUri: String?): String? {
+        storedUri?.toExistingFileOrNull()?.let { return it.toURI().toString() }
+        return findExistingAvatarFile()?.toURI()?.toString()
+    }
+
+    private fun extensionFor(mimeType: String?): String = when (mimeType?.lowercase()) {
+        "image/png" -> "png"
+        "image/webp" -> "webp"
+        else -> "jpg"
+    }
+
+    private fun avatarFile(extension: String): File =
+        File(appContext.filesDir, "profile_avatar.$extension")
+
+    private fun findExistingAvatarFile(): File? =
+        SUPPORTED_EXTENSIONS
+            .map(::avatarFile)
+            .firstOrNull { it.exists() && it.length() > 0L }
+
+    private fun deleteAllAvatarFiles() {
+        SUPPORTED_EXTENSIONS.forEach { ext ->
+            avatarFile(ext).takeIf { it.exists() }?.delete()
+        }
+    }
+
+    private fun String.toExistingFileOrNull(): File? = when {
+        startsWith("file:") -> runCatching { File(java.net.URI(this)) }.getOrNull()
+        startsWith("/") -> File(this)
+        else -> null
+    }?.takeIf { it.exists() && it.length() > 0L }
+
+    private companion object {
+        val SUPPORTED_EXTENSIONS = listOf("jpg", "png", "webp")
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileCache.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileCache.kt
@@ -1,0 +1,97 @@
+package com.example.leveluplife.data.player
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+
+private val Context.profileDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "profile_cache_prefs",
+)
+
+interface ProfileCache {
+    val profile: StateFlow<PlayerProfile?>
+    suspend fun loadPersisted()
+    suspend fun update(profile: PlayerProfile, etag: String? = null)
+    suspend fun updateLocalExtras(avatarUri: String?, bio: String)
+    fun currentEtag(): String?
+}
+
+class DefaultProfileCache(
+    context: Context,
+    private val avatarStorage: ProfileAvatarStorage,
+) : ProfileCache {
+    private val dataStore = context.applicationContext.profileDataStore
+    private val _profile = MutableStateFlow<PlayerProfile?>(null)
+    override val profile: StateFlow<PlayerProfile?> = _profile.asStateFlow()
+
+    private var etag: String? = null
+
+    override suspend fun loadPersisted() {
+        val prefs = dataStore.data.first()
+        val userName = prefs[KEY_USER_NAME] ?: return
+        _profile.value = PlayerProfile(
+            playerUserId = prefs[KEY_PLAYER_ID].orEmpty(),
+            userName = userName,
+            level = prefs[KEY_LEVEL]?.toIntOrNull() ?: 1,
+            classId = prefs[KEY_CLASS_ID]?.toIntOrNull() ?: 0,
+            className = prefs[KEY_CLASS_NAME].orEmpty(),
+            name = prefs[KEY_NAME].orEmpty(),
+            lastName = prefs[KEY_LAST_NAME].orEmpty(),
+            email = prefs[KEY_EMAIL].orEmpty(),
+            birthdate = prefs[KEY_BIRTHDATE],
+            avatarUri = avatarStorage.resolveDisplayUri(prefs[KEY_AVATAR_URI]),
+            bio = prefs[KEY_BIO].orEmpty(),
+        )
+        etag = prefs[KEY_ETAG]
+    }
+
+    override suspend fun update(profile: PlayerProfile, etag: String?) {
+        if (etag != null) this.etag = etag
+        _profile.update { profile }
+        dataStore.edit { prefs ->
+            prefs[KEY_PLAYER_ID] = profile.playerUserId
+            prefs[KEY_USER_NAME] = profile.userName
+            prefs[KEY_LEVEL] = profile.level.toString()
+            prefs[KEY_CLASS_ID] = profile.classId.toString()
+            prefs[KEY_CLASS_NAME] = profile.className
+            prefs[KEY_NAME] = profile.name
+            prefs[KEY_LAST_NAME] = profile.lastName
+            prefs[KEY_EMAIL] = profile.email
+            profile.birthdate?.let { prefs[KEY_BIRTHDATE] = it } ?: prefs.remove(KEY_BIRTHDATE)
+            profile.avatarUri?.let { prefs[KEY_AVATAR_URI] = it } ?: prefs.remove(KEY_AVATAR_URI)
+            prefs[KEY_BIO] = profile.bio
+            this.etag?.let { prefs[KEY_ETAG] = it }
+        }
+    }
+
+    override suspend fun updateLocalExtras(avatarUri: String?, bio: String) {
+        val current = _profile.value ?: return
+        update(current.copy(avatarUri = avatarUri, bio = bio))
+    }
+
+    override fun currentEtag(): String? = etag
+
+    private companion object {
+        val KEY_PLAYER_ID = stringPreferencesKey("player_id")
+        val KEY_USER_NAME = stringPreferencesKey("user_name")
+        val KEY_LEVEL = stringPreferencesKey("level")
+        val KEY_CLASS_ID = stringPreferencesKey("class_id")
+        val KEY_CLASS_NAME = stringPreferencesKey("class_name")
+        val KEY_NAME = stringPreferencesKey("name")
+        val KEY_LAST_NAME = stringPreferencesKey("last_name")
+        val KEY_EMAIL = stringPreferencesKey("email")
+        val KEY_BIRTHDATE = stringPreferencesKey("birthdate")
+        val KEY_AVATAR_URI = stringPreferencesKey("avatar_uri")
+        val KEY_BIO = stringPreferencesKey("bio")
+        val KEY_ETAG = stringPreferencesKey("etag")
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileError.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileError.kt
@@ -1,0 +1,28 @@
+package com.example.leveluplife.data.player
+
+sealed class ProfileField {
+    data object Name : ProfileField()
+    data object LastName : ProfileField()
+    data object Email : ProfileField()
+    data object Birthdate : ProfileField()
+    data object UserName : ProfileField()
+    data object Avatar : ProfileField()
+    data object Bio : ProfileField()
+    data object General : ProfileField()
+}
+
+sealed class ProfileError(open val message: String) {
+    data class Network(override val message: String) : ProfileError(message)
+    data class Unauthorized(override val message: String) : ProfileError(message)
+    data class NotFound(override val message: String) : ProfileError(message)
+    data class Conflict(override val message: String) : ProfileError(message)
+    data class PreconditionFailed(override val message: String) : ProfileError(message)
+    data class Validation(
+        override val message: String,
+        val fieldErrors: Map<ProfileField, String> = emptyMap(),
+    ) : ProfileError(message)
+    data class Server(override val message: String) : ProfileError(message)
+    data class Unknown(override val message: String) : ProfileError(message)
+}
+
+class ProfileException(val error: ProfileError) : Exception(error.message)

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileErrorMapper.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileErrorMapper.kt
@@ -1,0 +1,60 @@
+package com.example.leveluplife.data.player
+
+import com.example.leveluplife.data.network.dto.ApiErrorEnvelopeDto
+import com.example.leveluplife.data.network.dto.ApiProblemDetailsDto
+import kotlinx.serialization.json.Json
+
+object ProfileErrorMapper {
+
+    fun fromHttpCode(
+        code: Int,
+        body: String?,
+        json: Json,
+    ): ProfileError {
+        val envelope = body?.let { runCatching { json.decodeFromString<ApiErrorEnvelopeDto>(it) }.getOrNull() }
+        val problem = body?.let { runCatching { json.decodeFromString<ApiProblemDetailsDto>(it) }.getOrNull() }
+
+        return when (code) {
+            400 -> {
+                val fieldErrors = problem?.errors?.mapNotNull { (key, messages) ->
+                    mapServerField(key)?.let { field -> field to (messages.firstOrNull() ?: "") }
+                }?.toMap().orEmpty()
+
+                ProfileError.Validation(
+                    message = envelope?.details ?: problem?.title ?: "Invalid data.",
+                    fieldErrors = fieldErrors,
+                )
+            }
+            401 -> ProfileError.Unauthorized(
+                envelope?.details ?: "Session expired. Please sign in again.",
+            )
+            404 -> ProfileError.NotFound(
+                envelope?.details ?: "Player profile not found.",
+            )
+            409 -> ProfileError.Conflict(
+                envelope?.details ?: "Username is already taken.",
+            )
+            412 -> ProfileError.PreconditionFailed(
+                envelope?.details ?: "Profile was modified elsewhere. Reload and try again.",
+            )
+            in 500..599 -> ProfileError.Server(
+                envelope?.details ?: "Server error. Try again later.",
+            )
+            else -> ProfileError.Unknown(
+                envelope?.details ?: "Unexpected error occurred.",
+            )
+        }
+    }
+
+    private fun mapServerField(key: String): ProfileField? {
+        val normalized = key.lowercase()
+        return when {
+            normalized.contains("persondata.name") || normalized.endsWith(".name") -> ProfileField.Name
+            normalized.contains("persondata.lastname") || normalized.contains("lastname") -> ProfileField.LastName
+            normalized.contains("persondata.email") || normalized.endsWith(".email") -> ProfileField.Email
+            normalized.contains("persondata.birthdate") || normalized.contains("birthdate") -> ProfileField.Birthdate
+            normalized.contains("playerdata.username") || normalized.contains("username") -> ProfileField.UserName
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileRepository.kt
@@ -1,0 +1,144 @@
+package com.example.leveluplife.data.player
+
+import com.example.leveluplife.data.network.PlayerApi
+import com.example.leveluplife.data.network.dto.GetPlayerProfileResponseDto
+import com.example.leveluplife.data.network.dto.PersonUpdateRequestDto
+import com.example.leveluplife.data.network.dto.PlayerDataUpdateRequestDto
+import com.example.leveluplife.data.network.dto.PlayerProfileDto
+import com.example.leveluplife.data.network.dto.UpdatePlayerProfileRequestDto
+import com.example.leveluplife.data.network.dto.UpdatePlayerProfileResponseDto
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+interface ProfileRepository {
+    suspend fun fetchProfile(): Result<ProfileFetchResult>
+    suspend fun updateProfile(
+        etag: String,
+        name: String,
+        lastName: String,
+        email: String,
+        birthdate: String?,
+        userName: String,
+    ): Result<PlayerProfile>
+}
+
+class DefaultProfileRepository(
+    private val api: PlayerApi,
+    private val profileCache: ProfileCache,
+    private val json: Json,
+) : ProfileRepository {
+
+    override suspend fun fetchProfile(): Result<ProfileFetchResult> = try {
+        val response = api.getProfile()
+        val etag = response.headers()["ETag"].orEmpty()
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body == null) {
+                Result.failure(ProfileException(ProfileError.Unknown("Empty profile response.")))
+            } else {
+                val cached = profileCache.profile.value
+                val profile = body.toDomain(
+                    avatarUri = cached?.avatarUri,
+                    bio = cached?.bio.orEmpty(),
+                )
+                profileCache.update(profile, etag)
+                Result.success(ProfileFetchResult(profile = profile, etag = etag))
+            }
+        } else {
+            Result.failure(
+                ProfileException(
+                    ProfileErrorMapper.fromHttpCode(response.code(), response.errorBody()?.string(), json),
+                ),
+            )
+        }
+    } catch (_: SocketTimeoutException) {
+        Result.failure(ProfileException(ProfileError.Network("timeout")))
+    } catch (_: UnknownHostException) {
+        Result.failure(ProfileException(ProfileError.Network("unknown_host")))
+    } catch (e: IOException) {
+        Result.failure(ProfileException(ProfileError.Network(e.message ?: "network")))
+    }
+
+    override suspend fun updateProfile(
+        etag: String,
+        name: String,
+        lastName: String,
+        email: String,
+        birthdate: String?,
+        userName: String,
+    ): Result<PlayerProfile> = try {
+        val request = UpdatePlayerProfileRequestDto(
+            personData = PersonUpdateRequestDto(
+                name = name.trim(),
+                lastName = lastName.trim(),
+                email = email.trim(),
+                birthdate = birthdate?.trim()?.takeIf { it.isNotEmpty() },
+            ),
+            playerData = PlayerDataUpdateRequestDto(
+                userName = userName.trim(),
+            ),
+        )
+        val response = api.updateProfile(ifMatch = etag, body = request)
+        val newEtag = response.headers()["ETag"].orEmpty()
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body?.player == null) {
+                Result.failure(ProfileException(ProfileError.Unknown("Empty update response.")))
+            } else {
+                val cached = profileCache.profile.value
+                val profile = body.player.toDomain(
+                    avatarUri = cached?.avatarUri,
+                    bio = cached?.bio.orEmpty(),
+                )
+                profileCache.update(profile, newEtag.ifBlank { null })
+                Result.success(profile)
+            }
+        } else {
+            Result.failure(
+                ProfileException(
+                    ProfileErrorMapper.fromHttpCode(response.code(), response.errorBody()?.string(), json),
+                ),
+            )
+        }
+    } catch (_: SocketTimeoutException) {
+        Result.failure(ProfileException(ProfileError.Network("timeout")))
+    } catch (_: UnknownHostException) {
+        Result.failure(ProfileException(ProfileError.Network("unknown_host")))
+    } catch (e: IOException) {
+        Result.failure(ProfileException(ProfileError.Network(e.message ?: "network")))
+    }
+}
+
+private fun GetPlayerProfileResponseDto.toDomain(
+    avatarUri: String?,
+    bio: String,
+): PlayerProfile = PlayerProfile(
+    playerUserId = playerUserId,
+    userName = playerUserUserName,
+    level = playerUserLevel,
+    name = personData.name,
+    lastName = personData.lastName,
+    email = personData.email,
+    birthdate = personData.birthdate,
+    avatarUri = avatarUri,
+    bio = bio,
+)
+
+private fun PlayerProfileDto.toDomain(
+    avatarUri: String?,
+    bio: String,
+): PlayerProfile = PlayerProfile(
+    playerUserId = id.toString(),
+    userName = userName,
+    level = level,
+    classId = classId,
+    className = className,
+    name = person.name,
+    lastName = person.lastName,
+    email = person.email,
+    birthdate = person.birthdate,
+    avatarUri = avatarUri,
+    bio = bio,
+)

--- a/app/src/main/java/com/example/leveluplife/domain/validation/ProfileInputSanitizer.kt
+++ b/app/src/main/java/com/example/leveluplife/domain/validation/ProfileInputSanitizer.kt
@@ -1,0 +1,49 @@
+package com.example.leveluplife.domain.validation
+
+object ProfileInputSanitizer {
+
+    fun sanitizePersonName(input: String): String =
+        input
+            .replace(Regex("[\\p{Cc}\\p{Cf}]"), "")
+            .replace(Regex("\\s+"), " ")
+            .take(ProfileValidators.NAME_MAX)
+
+    fun sanitizeEmail(input: String): String =
+        input
+            .replace(Regex("[\\p{Cc}\\p{Cf}\\s]"), "")
+            .take(Validators.EMAIL_MAX)
+
+    fun sanitizeUserName(input: String): String =
+        input
+            .replace(Regex("\\s"), "")
+            .filter { it.isLetterOrDigit() || it == '.' || it == '_' || it == '-' }
+            .take(ProfileValidators.USERNAME_MAX)
+
+    fun sanitizeBirthdate(input: String): String =
+        input
+            .filter { it.isDigit() || it == '-' }
+            .take(ProfileValidators.BIRTHDATE_MAX_LENGTH)
+
+    fun sanitizeBio(input: String): String =
+        input
+            .replace(Regex("[\\p{Cc}]"), "")
+            .take(ProfileValidators.BIO_MAX)
+
+    fun sanitizeProfile(state: ProfileFormValues): ProfileFormValues = ProfileFormValues(
+        name = sanitizePersonName(state.name).trim(),
+        lastName = sanitizePersonName(state.lastName).trim(),
+        email = sanitizeEmail(state.email).trim(),
+        userName = sanitizeUserName(state.userName).trim(),
+        birthdate = sanitizeBirthdate(state.birthdate).trim(),
+        bio = sanitizeBio(state.bio).trim(),
+    )
+}
+
+data class ProfileFormValues(
+    val name: String = "",
+    val lastName: String = "",
+    val email: String = "",
+    val userName: String = "",
+    val birthdate: String = "",
+    val bio: String = "",
+)

--- a/app/src/main/java/com/example/leveluplife/domain/validation/ProfileValidators.kt
+++ b/app/src/main/java/com/example/leveluplife/domain/validation/ProfileValidators.kt
@@ -6,6 +6,7 @@ import java.util.GregorianCalendar
 sealed class AvatarValidationError {
     data object UnsupportedType : AvatarValidationError()
     data object TooLarge : AvatarValidationError()
+    data object PersistFailed : AvatarValidationError()
 }
 
 object AvatarValidator {

--- a/app/src/main/java/com/example/leveluplife/domain/validation/ProfileValidators.kt
+++ b/app/src/main/java/com/example/leveluplife/domain/validation/ProfileValidators.kt
@@ -1,0 +1,147 @@
+package com.example.leveluplife.domain.validation
+
+import java.util.Calendar
+import java.util.GregorianCalendar
+
+sealed class AvatarValidationError {
+    data object UnsupportedType : AvatarValidationError()
+    data object TooLarge : AvatarValidationError()
+}
+
+object AvatarValidator {
+    const val MAX_BYTES = 2 * 1024 * 1024 // 2 MB
+
+    private val ALLOWED_MIME_TYPES = setOf(
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    )
+
+    fun validate(mimeType: String?, sizeBytes: Long): AvatarValidationError? {
+        val normalizedMime = mimeType?.lowercase().orEmpty()
+        if (normalizedMime.isBlank() || normalizedMime !in ALLOWED_MIME_TYPES) {
+            return AvatarValidationError.UnsupportedType
+        }
+        if (sizeBytes <= 0L || sizeBytes > MAX_BYTES) {
+            return AvatarValidationError.TooLarge
+        }
+        return null
+    }
+}
+
+object ProfileValidators {
+    const val NAME_MIN = 2
+    const val NAME_MAX = 50
+    const val USERNAME_MIN = 3
+    const val USERNAME_MAX = 20
+    const val BIO_MAX = 200
+    const val BIRTHDATE_MAX_LENGTH = 10
+    const val BIRTHDATE_MIN_YEAR = 1900
+
+    private val BIRTHDATE_REGEX = Regex("^\\d{4}-\\d{2}-\\d{2}$")
+    private val PERSON_NAME_REGEX = Regex("^[\\p{L}](?:[\\p{L} '\\-]*[\\p{L}])?$")
+    private val USERNAME_REGEX = Regex("^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+    fun validateName(input: String): FieldError? =
+        validatePersonName(input, NAME_MIN, NAME_MAX)
+
+    fun validateLastName(input: String): FieldError? =
+        validatePersonName(input, NAME_MIN, NAME_MAX)
+
+    fun validateEmail(input: String): FieldError? {
+        val sanitized = ProfileInputSanitizer.sanitizeEmail(input).trim()
+        return when {
+            sanitized.isEmpty() -> FieldError.Required
+            sanitized.length > Validators.EMAIL_MAX -> FieldError.TooLong(Validators.EMAIL_MAX)
+            !Validators.isValidEmail(sanitized) -> FieldError.InvalidEmail
+            else -> null
+        }
+    }
+
+    fun validateUserName(input: String): FieldError? {
+        val sanitized = ProfileInputSanitizer.sanitizeUserName(input).trim()
+        return when {
+            sanitized.isEmpty() -> FieldError.Required
+            sanitized.length < USERNAME_MIN -> FieldError.TooShort(USERNAME_MIN)
+            sanitized.length > USERNAME_MAX -> FieldError.TooLong(USERNAME_MAX)
+            !USERNAME_REGEX.matches(sanitized) -> FieldError.InvalidUserNameOrEmail
+            else -> null
+        }
+    }
+
+    fun validateBirthdate(input: String): FieldError? {
+        val sanitized = ProfileInputSanitizer.sanitizeBirthdate(input).trim()
+        if (sanitized.isEmpty()) return null
+        if (!BIRTHDATE_REGEX.matches(sanitized)) return FieldError.InvalidBirthdate
+
+        val parts = sanitized.split("-")
+        if (parts.size != 3) return FieldError.InvalidBirthdate
+
+        val year = parts[0].toIntOrNull() ?: return FieldError.InvalidBirthdate
+        val month = parts[1].toIntOrNull() ?: return FieldError.InvalidBirthdate
+        val day = parts[2].toIntOrNull() ?: return FieldError.InvalidBirthdate
+
+        if (year < BIRTHDATE_MIN_YEAR) return FieldError.InvalidBirthdate
+        if (!isRealCalendarDate(year, month, day)) return FieldError.InvalidBirthdate
+        if (isFutureDate(year, month, day)) return FieldError.InvalidBirthdate
+
+        return null
+    }
+
+    fun validateBio(input: String): FieldError? {
+        val sanitized = ProfileInputSanitizer.sanitizeBio(input)
+        return if (sanitized.length > BIO_MAX) FieldError.TooLong(BIO_MAX) else null
+    }
+
+    fun validateAll(values: ProfileFormValues): Map<ProfileFieldKey, FieldError> {
+        val sanitized = ProfileInputSanitizer.sanitizeProfile(values)
+        return buildMap {
+            validateName(sanitized.name)?.let { put(ProfileFieldKey.NAME, it) }
+            validateLastName(sanitized.lastName)?.let { put(ProfileFieldKey.LAST_NAME, it) }
+            validateEmail(sanitized.email)?.let { put(ProfileFieldKey.EMAIL, it) }
+            validateUserName(sanitized.userName)?.let { put(ProfileFieldKey.USER_NAME, it) }
+            validateBirthdate(sanitized.birthdate)?.let { put(ProfileFieldKey.BIRTHDATE, it) }
+            validateBio(sanitized.bio)?.let { put(ProfileFieldKey.BIO, it) }
+        }
+    }
+
+    private fun validatePersonName(input: String, min: Int, max: Int): FieldError? {
+        val sanitized = ProfileInputSanitizer.sanitizePersonName(input).trim()
+        return when {
+            sanitized.isEmpty() -> FieldError.Required
+            sanitized.length < min -> FieldError.TooShort(min)
+            sanitized.length > max -> FieldError.TooLong(max)
+            !PERSON_NAME_REGEX.matches(sanitized) -> FieldError.InvalidCharacters
+            else -> null
+        }
+    }
+
+    private fun isRealCalendarDate(year: Int, month: Int, day: Int): Boolean {
+        if (month !in 1..12 || day < 1) return false
+        val calendar = GregorianCalendar(year, month - 1, day)
+        calendar.isLenient = false
+        return try {
+            calendar.time
+            calendar.get(Calendar.YEAR) == year &&
+                calendar.get(Calendar.MONTH) == month - 1 &&
+                calendar.get(Calendar.DAY_OF_MONTH) == day
+        } catch (_: IllegalArgumentException) {
+            false
+        }
+    }
+
+    private fun isFutureDate(year: Int, month: Int, day: Int): Boolean {
+        val today = Calendar.getInstance()
+        val candidate = GregorianCalendar(year, month - 1, day)
+        return candidate.after(today)
+    }
+}
+
+enum class ProfileFieldKey {
+    NAME,
+    LAST_NAME,
+    EMAIL,
+    USER_NAME,
+    BIRTHDATE,
+    BIO,
+}

--- a/app/src/main/java/com/example/leveluplife/domain/validation/Validators.kt
+++ b/app/src/main/java/com/example/leveluplife/domain/validation/Validators.kt
@@ -3,6 +3,9 @@ package com.example.leveluplife.domain.validation
 sealed class FieldError {
     object Required : FieldError()
     object InvalidUserNameOrEmail : FieldError()
+    object InvalidEmail : FieldError()
+    object InvalidBirthdate : FieldError()
+    object InvalidCharacters : FieldError()
     data class TooShort(val min: Int) : FieldError()
     data class TooLong(val max: Int) : FieldError()
 }
@@ -51,4 +54,6 @@ object Validators {
             else -> null
         }
     }
+
+    fun isValidEmail(input: String): Boolean = EMAIL_REGEX.matches(input.trim())
 }

--- a/app/src/main/java/com/example/leveluplife/ui/auth/LoginUiMessages.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/auth/LoginUiMessages.kt
@@ -11,6 +11,9 @@ import com.example.leveluplife.domain.validation.Validators
 fun FieldError.toMessage(): String = when (this) {
     is FieldError.Required -> stringResource(id = R.string.field_required)
     is FieldError.InvalidUserNameOrEmail -> stringResource(id = R.string.field_invalid_username_or_email)
+    is FieldError.InvalidEmail -> stringResource(id = R.string.field_invalid_email)
+    is FieldError.InvalidBirthdate -> stringResource(id = R.string.field_invalid_birthdate)
+    is FieldError.InvalidCharacters -> stringResource(id = R.string.field_invalid_characters)
     is FieldError.TooShort -> stringResource(
         id = R.string.field_min_length,
         min,

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.leveluplife.data.network.dto.HabitDto
+import com.example.leveluplife.data.player.ProfileCache
 import com.example.leveluplife.ui.theme.DarkBackground
 import com.example.leveluplife.ui.theme.DarkOnBackground
 import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
@@ -76,10 +77,12 @@ private val OrangeFire = Color(0xFFF59E0B)
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel,
-    onLoggedOut: () -> Unit,
+    profileCache: ProfileCache,
+    onOpenProfile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
+    val cachedProfile by profileCache.profile.collectAsState()
     val listState = rememberLazyListState()
 
     val shouldLoadMore by remember {
@@ -120,7 +123,7 @@ fun HomeScreen(
             ),
         ) {
             item {
-                HomeHeader(onLoggedOut = onLoggedOut)
+                HomeHeader(onOpenProfile = onOpenProfile, displayName = cachedProfile?.userName)
                 Spacer(Modifier.height(10.dp))
                 StatsRow()
                 Spacer(Modifier.height(20.dp))
@@ -210,38 +213,47 @@ fun HomeScreen(
 }
 
 @Composable
-private fun HomeHeader(onLoggedOut: () -> Unit) {
+private fun HomeHeader(onOpenProfile: () -> Unit, displayName: String?) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = buildAnnotatedString {
-                withStyle(
-                    SpanStyle(
-                        color = OrangeFire,
-                        fontStyle = FontStyle.Italic,
-                        fontWeight = FontWeight.ExtraBold,
-                    )
-                ) { append("LEVEL UP ") }
-                withStyle(
-                    SpanStyle(
-                        color = PurplePrimary,
-                        fontStyle = FontStyle.Italic,
-                        fontWeight = FontWeight.ExtraBold,
-                    )
-                ) { append("LIFE") }
-            },
-            fontSize = 22.sp,
-        )
+        Column {
+            Text(
+                text = buildAnnotatedString {
+                    withStyle(
+                        SpanStyle(
+                            color = OrangeFire,
+                            fontStyle = FontStyle.Italic,
+                            fontWeight = FontWeight.ExtraBold,
+                        )
+                    ) { append("LEVEL UP ") }
+                    withStyle(
+                        SpanStyle(
+                            color = PurplePrimary,
+                            fontStyle = FontStyle.Italic,
+                            fontWeight = FontWeight.ExtraBold,
+                        )
+                    ) { append("LIFE") }
+                },
+                fontSize = 22.sp,
+            )
+            if (!displayName.isNullOrBlank()) {
+                Text(
+                    text = displayName,
+                    color = DarkOnSurfaceVariant,
+                    fontSize = 12.sp,
+                )
+            }
+        }
         IconButton(
-            onClick = onLoggedOut,
+            onClick = onOpenProfile,
             modifier = Modifier
                 .background(DarkSurfaceVariant, RoundedCornerShape(14.dp))
                 .size(46.dp),
         ) {
-            Icon(Icons.Filled.Person, contentDescription = "Perfil / Cerrar sesión", tint = DarkOnBackground)
+            Icon(Icons.Filled.Person, contentDescription = "Perfil", tint = DarkOnBackground)
         }
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -1,6 +1,7 @@
 package com.example.leveluplife.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -12,10 +13,13 @@ import com.example.leveluplife.ui.auth.LoginScreen
 import com.example.leveluplife.ui.auth.LoginViewModel
 import com.example.leveluplife.ui.home.HomeScreen
 import com.example.leveluplife.ui.home.HomeViewModel
+import com.example.leveluplife.ui.profile.ProfileScreen
+import com.example.leveluplife.ui.profile.ProfileViewModel
 
 object Routes {
     const val LOGIN = "login"
     const val DASHBOARD = "dashboard"
+    const val PROFILE = "profile"
 }
 
 @Composable
@@ -28,6 +32,16 @@ fun AppNavigation(
         Routes.DASHBOARD
     } else {
         Routes.LOGIN
+    }
+
+    LaunchedEffect(container.sessionEvents) {
+        container.sessionEvents.expired.collect {
+            container.authRepository.logout()
+            navController.navigate(Routes.LOGIN) {
+                popUpTo(Routes.DASHBOARD) { inclusive = true }
+                launchSingleTop = true
+            }
+        }
     }
 
     NavHost(
@@ -59,7 +73,24 @@ fun AppNavigation(
             )
             HomeScreen(
                 viewModel = vm,
-                onLoggedOut = {
+                profileCache = container.profileCache,
+                onOpenProfile = {
+                    navController.navigate(Routes.PROFILE) { launchSingleTop = true }
+                },
+            )
+        }
+        composable(Routes.PROFILE) {
+            val vm: ProfileViewModel = viewModel(
+                factory = ProfileViewModel.Factory(
+                    container.profileRepository,
+                    container.profileCache,
+                    container.profileAvatarStorage,
+                ),
+            )
+            ProfileScreen(
+                viewModel = vm,
+                onBack = { navController.popBackStack() },
+                onLogout = {
                     container.authRepository.logout()
                     navController.navigate(Routes.LOGIN) {
                         popUpTo(Routes.DASHBOARD) { inclusive = true }

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileScreen.kt
@@ -62,6 +62,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.leveluplife.R
+import com.example.leveluplife.domain.validation.AvatarValidationError
 import com.example.leveluplife.domain.validation.FieldError
 import com.example.leveluplife.domain.validation.ProfileValidators
 import com.example.leveluplife.ui.auth.toMessage
@@ -403,7 +404,7 @@ private fun ProfileInfoRow(label: String, value: String) {
 @Composable
 private fun AvatarSection(
     avatarUri: String?,
-    avatarError: FieldError?,
+    avatarError: AvatarValidationError?,
     serverError: String?,
     editable: Boolean,
     onPickAvatar: () -> Unit,
@@ -453,10 +454,7 @@ private fun AvatarSection(
             )
             avatarError?.let {
                 Text(
-                    text = when (it) {
-                        is FieldError.TooLong -> stringResource(R.string.profile_avatar_too_large)
-                        else -> stringResource(R.string.profile_avatar_invalid_type)
-                    },
+                    text = it.toMessage(),
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
                 )

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileScreen.kt
@@ -1,0 +1,530 @@
+package com.example.leveluplife.ui.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.leveluplife.R
+import com.example.leveluplife.domain.validation.FieldError
+import com.example.leveluplife.domain.validation.ProfileValidators
+import com.example.leveluplife.ui.auth.toMessage
+import com.example.leveluplife.ui.components.LulErrorAlertDialog
+import com.example.leveluplife.ui.components.LulPrimaryButton
+import com.example.leveluplife.ui.theme.DarkBackground
+import com.example.leveluplife.ui.theme.DarkOnBackground
+import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
+import com.example.leveluplife.ui.theme.DarkSurface
+import com.example.leveluplife.ui.theme.DarkSurfaceVariant
+import com.example.leveluplife.ui.theme.PurplePrimary
+
+object ProfileTestTags {
+    const val SCREEN = "profile_screen"
+    const val EDIT_BUTTON = "profile_edit_button"
+    const val SAVE_BUTTON = "profile_save_button"
+    const val CANCEL_BUTTON = "profile_cancel_button"
+    const val AVATAR_BUTTON = "profile_avatar_button"
+    const val LOGOUT_BUTTON = "profile_logout_button"
+    const val LOGOUT_CONFIRM_DIALOG = "profile_logout_confirm_dialog"
+    const val LOGOUT_CONFIRM_BUTTON = "profile_logout_confirm_button"
+    const val NAME_FIELD = "profile_name_field"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    viewModel: ProfileViewModel,
+    onBack: () -> Unit,
+    onLogout: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showLogoutConfirm by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val successMessage = stringResource(R.string.profile_save_success)
+
+    val avatarPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        val resolver = context.contentResolver
+        val mimeType = resolver.getType(uri)
+        val sizeBytes = resolver.openInputStream(uri)?.use { it.available().toLong() } ?: 0L
+        viewModel.onAvatarSelected(uri.toString(), mimeType, sizeBytes)
+    }
+
+    LaunchedEffect(state.profileSaved, successMessage) {
+        if (state.profileSaved) {
+            snackbarHostState.showSnackbar(successMessage)
+            viewModel.consumeSavedEvent()
+        }
+    }
+
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(ProfileTestTags.SCREEN),
+        containerColor = DarkBackground,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = PurplePrimary)
+            }
+            return@Scaffold
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .navigationBarsPadding()
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.profile_back),
+                        tint = DarkOnBackground,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.profile_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = DarkOnBackground,
+                )
+            }
+
+            Text(
+                text = if (state.isEditing) {
+                    stringResource(R.string.profile_edit_subtitle)
+                } else {
+                    stringResource(R.string.profile_subtitle)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = DarkOnSurfaceVariant,
+            )
+
+            AvatarSection(
+                avatarUri = state.pendingAvatarUri ?: state.avatarUri,
+                avatarError = if (state.isEditing) state.avatarError else null,
+                serverError = if (state.isEditing) state.serverFieldErrors[ProfileFormField.AVATAR] else null,
+                editable = state.isEditing,
+                onPickAvatar = {
+                    avatarPicker.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                    )
+                },
+            )
+
+            if (state.className.isNotBlank()) {
+                Text(
+                    text = stringResource(R.string.profile_class_label) + ": ${state.className}",
+                    color = DarkOnSurfaceVariant,
+                )
+                Text(
+                    text = stringResource(R.string.profile_level_label, state.level),
+                    color = DarkOnSurfaceVariant,
+                )
+            }
+
+            if (state.isEditing) {
+                ProfileEditForm(state = state, viewModel = viewModel)
+            } else {
+                ProfileViewCard(state = state)
+                LulPrimaryButton(
+                    text = stringResource(R.string.profile_edit),
+                    onClick = viewModel::onStartEditing,
+                    modifier = Modifier.testTag(ProfileTestTags.EDIT_BUTTON),
+                )
+            }
+
+            TextButton(
+                onClick = { showLogoutConfirm = true },
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .testTag(ProfileTestTags.LOGOUT_BUTTON),
+            ) {
+                Text(stringResource(R.string.profile_logout), color = PurplePrimary)
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+
+    if (showLogoutConfirm) {
+        AlertDialog(
+            onDismissRequest = { showLogoutConfirm = false },
+            modifier = Modifier.testTag(ProfileTestTags.LOGOUT_CONFIRM_DIALOG),
+            title = { Text(stringResource(R.string.profile_logout_confirm_title)) },
+            text = { Text(stringResource(R.string.profile_logout_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showLogoutConfirm = false
+                        onLogout()
+                    },
+                    modifier = Modifier.testTag(ProfileTestTags.LOGOUT_CONFIRM_BUTTON),
+                ) {
+                    Text(stringResource(R.string.profile_logout_confirm), color = PurplePrimary)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLogoutConfirm = false }) {
+                    Text(stringResource(R.string.profile_cancel_edit))
+                }
+            },
+        )
+    }
+
+    if (state.bannerError != null) {
+        val message = mapBannerMessage(state.bannerError!!)
+        LulErrorAlertDialog(
+            title = stringResource(R.string.error_dialog_title),
+            message = message,
+            dismissText = stringResource(R.string.login_dismiss),
+            onDismiss = viewModel::dismissError,
+            retryText = if (state.bannerError == "network") stringResource(R.string.profile_retry) else null,
+            onRetry = if (state.bannerError == "network") viewModel::loadProfile else null,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.ProfileEditForm(
+    state: ProfileUiState,
+    viewModel: ProfileViewModel,
+) {
+    ProfileTextField(
+        value = state.name,
+        onValueChange = viewModel::onNameChange,
+        label = stringResource(R.string.profile_name_label),
+        error = state.nameError,
+        serverError = state.serverFieldErrors[ProfileFormField.NAME],
+        testTag = ProfileTestTags.NAME_FIELD,
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Words,
+            autoCorrectEnabled = true,
+        ),
+    )
+    ProfileTextField(
+        value = state.lastName,
+        onValueChange = viewModel::onLastNameChange,
+        label = stringResource(R.string.profile_last_name_label),
+        error = state.lastNameError,
+        serverError = state.serverFieldErrors[ProfileFormField.LAST_NAME],
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Words,
+            autoCorrectEnabled = true,
+        ),
+    )
+    ProfileTextField(
+        value = state.email,
+        onValueChange = viewModel::onEmailChange,
+        label = stringResource(R.string.profile_email_label),
+        error = state.emailError,
+        serverError = state.serverFieldErrors[ProfileFormField.EMAIL],
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Email,
+            autoCorrectEnabled = false,
+        ),
+    )
+    ProfileTextField(
+        value = state.userName,
+        onValueChange = viewModel::onUserNameChange,
+        label = stringResource(R.string.profile_username_label),
+        error = state.userNameError,
+        serverError = state.serverFieldErrors[ProfileFormField.USER_NAME],
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Ascii,
+            autoCorrectEnabled = false,
+        ),
+    )
+    ProfileTextField(
+        value = state.birthdate,
+        onValueChange = viewModel::onBirthdateChange,
+        label = stringResource(R.string.profile_birthdate_label),
+        placeholder = stringResource(R.string.profile_birthdate_hint),
+        error = state.birthdateError,
+        serverError = state.serverFieldErrors[ProfileFormField.BIRTHDATE],
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Text,
+            autoCorrectEnabled = false,
+        ),
+    )
+    ProfileTextField(
+        value = state.bio,
+        onValueChange = viewModel::onBioChange,
+        label = stringResource(R.string.profile_bio_label),
+        placeholder = stringResource(R.string.profile_bio_hint),
+        error = state.bioError,
+        serverError = state.serverFieldErrors[ProfileFormField.BIO],
+        minLines = 3,
+        maxLength = ProfileValidators.BIO_MAX,
+    )
+
+    LulPrimaryButton(
+        text = if (state.isSaving) {
+            stringResource(R.string.profile_saving)
+        } else {
+            stringResource(R.string.profile_save)
+        },
+        onClick = viewModel::onSubmit,
+        enabled = !state.isSaving,
+        isLoading = state.isSaving,
+        modifier = Modifier.testTag(ProfileTestTags.SAVE_BUTTON),
+    )
+
+    TextButton(
+        onClick = viewModel::onCancelEditing,
+        enabled = !state.isSaving,
+        modifier = Modifier
+            .align(Alignment.CenterHorizontally)
+            .testTag(ProfileTestTags.CANCEL_BUTTON),
+    ) {
+        Text(stringResource(R.string.profile_cancel_edit), color = PurplePrimary)
+    }
+}
+
+@Composable
+private fun ProfileViewCard(state: ProfileUiState) {
+    val notSet = stringResource(R.string.profile_not_set)
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = DarkSurface),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            ProfileInfoRow(stringResource(R.string.profile_name_label), state.name.ifBlank { notSet })
+            ProfileInfoRow(stringResource(R.string.profile_last_name_label), state.lastName.ifBlank { notSet })
+            ProfileInfoRow(stringResource(R.string.profile_email_label), state.email.ifBlank { notSet })
+            ProfileInfoRow(stringResource(R.string.profile_username_label), state.userName.ifBlank { notSet })
+            ProfileInfoRow(
+                stringResource(R.string.profile_birthdate_label),
+                state.birthdate.ifBlank { notSet },
+            )
+            ProfileInfoRow(
+                stringResource(R.string.profile_bio_label),
+                state.bio.ifBlank { notSet },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileInfoRow(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = DarkOnSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            color = DarkOnBackground,
+        )
+    }
+}
+
+@Composable
+private fun AvatarSection(
+    avatarUri: String?,
+    avatarError: FieldError?,
+    serverError: String?,
+    editable: Boolean,
+    onPickAvatar: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(96.dp)
+                .clip(CircleShape)
+                .background(DarkSurfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (avatarUri != null) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(avatarUri)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = stringResource(R.string.cd_profile_avatar),
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                Icon(
+                    Icons.Filled.Person,
+                    contentDescription = stringResource(R.string.cd_profile_avatar),
+                    tint = DarkOnBackground,
+                    modifier = Modifier.size(48.dp),
+                )
+            }
+        }
+        if (editable) {
+            OutlinedButton(
+                onClick = onPickAvatar,
+                modifier = Modifier.testTag(ProfileTestTags.AVATAR_BUTTON),
+            ) {
+                Text(stringResource(R.string.profile_avatar_change))
+            }
+            Text(
+                text = stringResource(R.string.profile_avatar_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = DarkOnSurfaceVariant,
+            )
+            avatarError?.let {
+                Text(
+                    text = when (it) {
+                        is FieldError.TooLong -> stringResource(R.string.profile_avatar_too_large)
+                        else -> stringResource(R.string.profile_avatar_invalid_type)
+                    },
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            serverError?.let {
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    error: FieldError?,
+    serverError: String?,
+    placeholder: String = "",
+    minLines: Int = 1,
+    maxLength: Int? = null,
+    testTag: String? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+) {
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = PurplePrimary,
+        unfocusedBorderColor = DarkSurfaceVariant,
+        focusedTextColor = DarkOnBackground,
+        unfocusedTextColor = DarkOnBackground,
+        cursorColor = PurplePrimary,
+    )
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        placeholder = if (placeholder.isNotBlank()) {
+            { Text(placeholder) }
+        } else {
+            null
+        },
+        isError = error != null || serverError != null,
+        supportingText = {
+            when {
+                serverError != null -> Text(serverError)
+                error != null -> Text(error.toMessage())
+                maxLength != null -> Text("${value.length}/$maxLength")
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
+        minLines = minLines,
+        maxLines = if (minLines > 1) 5 else 1,
+        singleLine = minLines == 1,
+        shape = RoundedCornerShape(14.dp),
+        colors = fieldColors,
+        keyboardOptions = keyboardOptions,
+    )
+}
+
+@Composable
+private fun mapBannerMessage(key: String): String = when (key) {
+    "network" -> stringResource(R.string.profile_error_network)
+    "conflict" -> stringResource(R.string.profile_error_conflict)
+    "precondition_failed" -> stringResource(R.string.profile_error_precondition)
+    else -> key.ifBlank { stringResource(R.string.login_error_unknown) }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiMessages.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiMessages.kt
@@ -10,6 +10,7 @@ import com.example.leveluplife.domain.validation.AvatarValidationError
 fun AvatarValidationError.toMessage(): String = when (this) {
     AvatarValidationError.TooLarge -> stringResource(R.string.profile_avatar_too_large)
     AvatarValidationError.UnsupportedType -> stringResource(R.string.profile_avatar_invalid_type)
+    AvatarValidationError.PersistFailed -> stringResource(R.string.profile_avatar_persist_failed)
 }
 
 @Composable

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiMessages.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiMessages.kt
@@ -1,0 +1,25 @@
+package com.example.leveluplife.ui.profile
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.example.leveluplife.R
+import com.example.leveluplife.data.player.ProfileError
+import com.example.leveluplife.domain.validation.AvatarValidationError
+
+@Composable
+fun AvatarValidationError.toMessage(): String = when (this) {
+    AvatarValidationError.TooLarge -> stringResource(R.string.profile_avatar_too_large)
+    AvatarValidationError.UnsupportedType -> stringResource(R.string.profile_avatar_invalid_type)
+}
+
+@Composable
+fun ProfileError.toMessage(): String = when (this) {
+    is ProfileError.Network -> stringResource(R.string.profile_error_network)
+    is ProfileError.Unauthorized -> stringResource(R.string.login_error_session_expired)
+    is ProfileError.NotFound -> stringResource(R.string.profile_load_error)
+    is ProfileError.Conflict -> stringResource(R.string.profile_error_conflict)
+    is ProfileError.PreconditionFailed -> stringResource(R.string.profile_error_precondition)
+    is ProfileError.Validation -> message.ifBlank { stringResource(R.string.login_error_bad_request) }
+    is ProfileError.Server -> stringResource(R.string.login_error_server)
+    is ProfileError.Unknown -> stringResource(R.string.login_error_unknown)
+}

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiState.kt
@@ -1,0 +1,76 @@
+package com.example.leveluplife.ui.profile
+
+import com.example.leveluplife.data.player.ProfileField
+import com.example.leveluplife.domain.validation.FieldError
+
+data class ProfileFormSnapshot(
+    val name: String = "",
+    val lastName: String = "",
+    val email: String = "",
+    val userName: String = "",
+    val birthdate: String = "",
+    val bio: String = "",
+    val avatarUri: String? = null,
+) {
+    companion object {
+        fun from(state: ProfileUiState): ProfileFormSnapshot = ProfileFormSnapshot(
+            name = state.name,
+            lastName = state.lastName,
+            email = state.email,
+            userName = state.userName,
+            birthdate = state.birthdate,
+            bio = state.bio,
+            avatarUri = state.avatarUri,
+        )
+    }
+}
+
+data class ProfileUiState(
+    val isLoading: Boolean = true,
+    val isEditing: Boolean = false,
+    val isSaving: Boolean = false,
+    val name: String = "",
+    val lastName: String = "",
+    val email: String = "",
+    val userName: String = "",
+    val birthdate: String = "",
+    val bio: String = "",
+    val className: String = "",
+    val level: Int = 1,
+    val avatarUri: String? = null,
+    val pendingAvatarUri: String? = null,
+    val editSnapshot: ProfileFormSnapshot? = null,
+    val etag: String = "",
+    val nameError: FieldError? = null,
+    val lastNameError: FieldError? = null,
+    val emailError: FieldError? = null,
+    val userNameError: FieldError? = null,
+    val birthdateError: FieldError? = null,
+    val bioError: FieldError? = null,
+    val avatarError: FieldError? = null,
+    val serverFieldErrors: Map<ProfileFormField, String> = emptyMap(),
+    val bannerError: String? = null,
+    val profileSaved: Boolean = false,
+    val successMessage: String? = null,
+)
+
+enum class ProfileFormField {
+    NAME,
+    LAST_NAME,
+    EMAIL,
+    USER_NAME,
+    BIRTHDATE,
+    BIO,
+    AVATAR,
+}
+
+fun ProfileField.toFormField(): ProfileFormField? = when (this) {
+    ProfileField.Name -> ProfileFormField.NAME
+    ProfileField.LastName -> ProfileFormField.LAST_NAME
+    ProfileField.Email -> ProfileFormField.EMAIL
+    ProfileField.UserName -> ProfileFormField.USER_NAME
+    ProfileField.Birthdate -> ProfileFormField.BIRTHDATE
+    ProfileField.Bio -> ProfileFormField.BIO
+    ProfileField.Avatar -> ProfileFormField.AVATAR
+    ProfileField.General -> null
+}

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileUiState.kt
@@ -1,6 +1,7 @@
 package com.example.leveluplife.ui.profile
 
 import com.example.leveluplife.data.player.ProfileField
+import com.example.leveluplife.domain.validation.AvatarValidationError
 import com.example.leveluplife.domain.validation.FieldError
 
 data class ProfileFormSnapshot(
@@ -47,7 +48,7 @@ data class ProfileUiState(
     val userNameError: FieldError? = null,
     val birthdateError: FieldError? = null,
     val bioError: FieldError? = null,
-    val avatarError: FieldError? = null,
+    val avatarError: AvatarValidationError? = null,
     val serverFieldErrors: Map<ProfileFormField, String> = emptyMap(),
     val bannerError: String? = null,
     val profileSaved: Boolean = false,

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileViewModel.kt
@@ -128,7 +128,7 @@ class ProfileViewModel(
                 viewModelScope.launch {
                     val persistedUri = avatarStorage.persistFromPickerUri(uri, mimeType)
                     if (persistedUri == null) {
-                        _state.update { it.copy(avatarError = FieldError.InvalidEmail) }
+                        _state.update { it.copy(avatarError = AvatarValidationError.PersistFailed) }
                         return@launch
                     }
                     _state.update {
@@ -143,10 +143,10 @@ class ProfileViewModel(
                 }
             }
             AvatarValidationError.TooLarge -> {
-                _state.update { it.copy(avatarError = FieldError.TooLong(AvatarValidator.MAX_BYTES)) }
+                _state.update { it.copy(avatarError = AvatarValidationError.TooLarge) }
             }
             AvatarValidationError.UnsupportedType -> {
-                _state.update { it.copy(avatarError = FieldError.InvalidEmail) }
+                _state.update { it.copy(avatarError = AvatarValidationError.UnsupportedType) }
             }
         }
     }

--- a/app/src/main/java/com/example/leveluplife/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,398 @@
+package com.example.leveluplife.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.leveluplife.data.player.PlayerProfile
+import com.example.leveluplife.data.player.ProfileAvatarStorage
+import com.example.leveluplife.data.player.ProfileCache
+import com.example.leveluplife.data.player.ProfileError
+import com.example.leveluplife.data.player.ProfileException
+import com.example.leveluplife.data.player.ProfileRepository
+import com.example.leveluplife.domain.validation.AvatarValidationError
+import com.example.leveluplife.domain.validation.AvatarValidator
+import com.example.leveluplife.domain.validation.FieldError
+import com.example.leveluplife.domain.validation.ProfileFieldKey
+import com.example.leveluplife.domain.validation.ProfileFormValues
+import com.example.leveluplife.domain.validation.ProfileInputSanitizer
+import com.example.leveluplife.domain.validation.ProfileValidators
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ProfileViewModel(
+    private val profileRepository: ProfileRepository,
+    private val profileCache: ProfileCache,
+    private val avatarStorage: ProfileAvatarStorage,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ProfileUiState())
+    val state: StateFlow<ProfileUiState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            profileCache.loadPersisted()
+            loadProfile()
+        }
+    }
+
+    fun loadProfile() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, bannerError = null) }
+            profileRepository.fetchProfile()
+                .onSuccess { result ->
+                    applyProfile(result.profile, result.etag)
+                    _state.update { it.copy(isLoading = false) }
+                }
+                .onFailure { throwable ->
+                    if ((throwable as? ProfileException)?.error is ProfileError.Unauthorized) {
+                        _state.update { it.copy(isLoading = false) }
+                        return@launch
+                    }
+                    val cached = profileCache.profile.value
+                    if (cached != null) {
+                        val etag = profileCache.currentEtag().orEmpty()
+                        applyProfile(cached, etag)
+                        _state.update { it.copy(isLoading = false) }
+                    } else {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                bannerError = mapThrowableMessage(throwable),
+                            )
+                        }
+                    }
+                }
+        }
+    }
+
+    fun onNameChange(value: String) = onFieldChange(
+        rawValue = value,
+        sanitize = ProfileInputSanitizer::sanitizePersonName,
+        validate = ProfileValidators::validateName,
+        field = ProfileFormField.NAME,
+    ) { current, sanitized, error ->
+        current.copy(name = sanitized, nameError = error)
+    }
+
+    fun onLastNameChange(value: String) = onFieldChange(
+        rawValue = value,
+        sanitize = ProfileInputSanitizer::sanitizePersonName,
+        validate = ProfileValidators::validateLastName,
+        field = ProfileFormField.LAST_NAME,
+    ) { current, sanitized, error ->
+        current.copy(lastName = sanitized, lastNameError = error)
+    }
+
+    fun onEmailChange(value: String) = onFieldChange(
+        rawValue = value,
+        sanitize = ProfileInputSanitizer::sanitizeEmail,
+        validate = ProfileValidators::validateEmail,
+        field = ProfileFormField.EMAIL,
+    ) { current, sanitized, error ->
+        current.copy(email = sanitized, emailError = error)
+    }
+
+    fun onUserNameChange(value: String) = onFieldChange(
+        rawValue = value,
+        sanitize = ProfileInputSanitizer::sanitizeUserName,
+        validate = ProfileValidators::validateUserName,
+        field = ProfileFormField.USER_NAME,
+    ) { current, sanitized, error ->
+        current.copy(userName = sanitized, userNameError = error)
+    }
+
+    fun onBirthdateChange(value: String) = onFieldChange(
+        rawValue = value,
+        sanitize = ProfileInputSanitizer::sanitizeBirthdate,
+        validate = ProfileValidators::validateBirthdate,
+        field = ProfileFormField.BIRTHDATE,
+    ) { current, sanitized, error ->
+        current.copy(birthdate = sanitized, birthdateError = error)
+    }
+
+    fun onBioChange(value: String) = onFieldChange(
+        rawValue = value,
+        sanitize = ProfileInputSanitizer::sanitizeBio,
+        validate = ProfileValidators::validateBio,
+        field = ProfileFormField.BIO,
+    ) { current, sanitized, error ->
+        current.copy(bio = sanitized, bioError = error)
+    }
+
+    fun onAvatarSelected(uri: String, mimeType: String?, sizeBytes: Long) {
+        when (AvatarValidator.validate(mimeType, sizeBytes)) {
+            null -> {
+                viewModelScope.launch {
+                    val persistedUri = avatarStorage.persistFromPickerUri(uri, mimeType)
+                    if (persistedUri == null) {
+                        _state.update { it.copy(avatarError = FieldError.InvalidEmail) }
+                        return@launch
+                    }
+                    _state.update {
+                        it.copy(
+                            pendingAvatarUri = persistedUri,
+                            avatarUri = persistedUri,
+                            avatarError = null,
+                            serverFieldErrors = it.serverFieldErrors - ProfileFormField.AVATAR,
+                        )
+                    }
+                    profileCache.updateLocalExtras(persistedUri, _state.value.bio)
+                }
+            }
+            AvatarValidationError.TooLarge -> {
+                _state.update { it.copy(avatarError = FieldError.TooLong(AvatarValidator.MAX_BYTES)) }
+            }
+            AvatarValidationError.UnsupportedType -> {
+                _state.update { it.copy(avatarError = FieldError.InvalidEmail) }
+            }
+        }
+    }
+
+    fun onStartEditing() {
+        val sanitized = sanitizeState(_state.value)
+        _state.update {
+            sanitized.copy(
+                isEditing = true,
+                editSnapshot = ProfileFormSnapshot.from(sanitized),
+                nameError = null,
+                lastNameError = null,
+                emailError = null,
+                userNameError = null,
+                birthdateError = null,
+                bioError = null,
+                avatarError = null,
+                serverFieldErrors = emptyMap(),
+                bannerError = null,
+                pendingAvatarUri = null,
+            )
+        }
+    }
+
+    fun onCancelEditing() {
+        val snapshot = _state.value.editSnapshot ?: run {
+            _state.update { it.copy(isEditing = false) }
+            return
+        }
+        _state.update {
+            it.copy(
+                isEditing = false,
+                editSnapshot = null,
+                name = snapshot.name,
+                lastName = snapshot.lastName,
+                email = snapshot.email,
+                userName = snapshot.userName,
+                birthdate = snapshot.birthdate,
+                bio = snapshot.bio,
+                avatarUri = snapshot.avatarUri,
+                pendingAvatarUri = null,
+                nameError = null,
+                lastNameError = null,
+                emailError = null,
+                userNameError = null,
+                birthdateError = null,
+                bioError = null,
+                avatarError = null,
+                serverFieldErrors = emptyMap(),
+                bannerError = null,
+            )
+        }
+    }
+
+    fun onSubmit() {
+        val validated = validateAll()
+        _state.value = validated
+        if (hasValidationErrors(validated)) return
+
+        viewModelScope.launch {
+            val etag = validated.etag.ifBlank { profileCache.currentEtag().orEmpty() }
+            if (etag.isBlank()) {
+                _state.update { it.copy(bannerError = "missing_etag") }
+                return@launch
+            }
+
+            _state.update { it.copy(isSaving = true, bannerError = null, profileSaved = false) }
+
+            profileCache.updateLocalExtras(
+                avatarUri = validated.pendingAvatarUri ?: validated.avatarUri,
+                bio = validated.bio,
+            )
+
+            profileRepository.updateProfile(
+                etag = etag,
+                name = validated.name,
+                lastName = validated.lastName,
+                email = validated.email,
+                birthdate = validated.birthdate.ifBlank { null },
+                userName = validated.userName,
+            ).onSuccess { profile ->
+                applyProfile(
+                    profile.copy(
+                        avatarUri = validated.pendingAvatarUri ?: validated.avatarUri,
+                        bio = validated.bio,
+                    ),
+                    profileCache.currentEtag().orEmpty(),
+                )
+                _state.update {
+                    it.copy(
+                        isSaving = false,
+                        isEditing = false,
+                        editSnapshot = null,
+                        profileSaved = true,
+                        successMessage = "saved",
+                        pendingAvatarUri = null,
+                    )
+                }
+            }.onFailure { throwable ->
+                handleSubmitFailure(throwable)
+            }
+        }
+    }
+
+    fun consumeSavedEvent() {
+        _state.update { it.copy(profileSaved = false, successMessage = null) }
+    }
+
+    fun dismissError() {
+        _state.update { it.copy(bannerError = null) }
+    }
+
+    private fun handleSubmitFailure(throwable: Throwable) {
+        when (val error = (throwable as? ProfileException)?.error) {
+            is ProfileError.Unauthorized -> {
+                _state.update { it.copy(isSaving = false) }
+            }
+            is ProfileError.Validation -> {
+                val serverErrors = error.fieldErrors.mapNotNull { (field, message) ->
+                    field.toFormField()?.let { it to message }
+                }.toMap()
+                _state.update {
+                    it.copy(
+                        isSaving = false,
+                        bannerError = error.message,
+                        serverFieldErrors = serverErrors,
+                    )
+                }
+            }
+            is ProfileError.PreconditionFailed -> {
+                _state.update { it.copy(isSaving = false, bannerError = "precondition_failed") }
+                loadProfile()
+            }
+            else -> {
+                _state.update {
+                    it.copy(
+                        isSaving = false,
+                        bannerError = mapThrowableMessage(throwable),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun validateAll(): ProfileUiState {
+        val sanitized = sanitizeState(_state.value)
+        val errors = ProfileValidators.validateAll(sanitized.toFormValues())
+        return sanitized.copy(
+            nameError = errors[ProfileFieldKey.NAME],
+            lastNameError = errors[ProfileFieldKey.LAST_NAME],
+            emailError = errors[ProfileFieldKey.EMAIL],
+            userNameError = errors[ProfileFieldKey.USER_NAME],
+            birthdateError = errors[ProfileFieldKey.BIRTHDATE],
+            bioError = errors[ProfileFieldKey.BIO],
+            avatarError = _state.value.avatarError,
+        )
+    }
+
+    private fun sanitizeState(state: ProfileUiState): ProfileUiState {
+        val sanitized = ProfileInputSanitizer.sanitizeProfile(state.toFormValues())
+        return state.copy(
+            name = sanitized.name,
+            lastName = sanitized.lastName,
+            email = sanitized.email,
+            userName = sanitized.userName,
+            birthdate = sanitized.birthdate,
+            bio = sanitized.bio,
+        )
+    }
+
+    private fun ProfileUiState.toFormValues(): ProfileFormValues = ProfileFormValues(
+        name = name,
+        lastName = lastName,
+        email = email,
+        userName = userName,
+        birthdate = birthdate,
+        bio = bio,
+    )
+
+    private fun onFieldChange(
+        rawValue: String,
+        sanitize: (String) -> String,
+        validate: (String) -> FieldError?,
+        field: ProfileFormField,
+        reducer: (ProfileUiState, String, FieldError?) -> ProfileUiState,
+    ) {
+        val sanitized = sanitize(rawValue)
+        _state.update { current ->
+            val error = if (current.isEditing) validate(sanitized) else null
+            reducer(current, sanitized, error)
+                .copy(serverFieldErrors = current.serverFieldErrors - field)
+        }
+    }
+
+    private fun hasValidationErrors(state: ProfileUiState): Boolean =
+        listOf(
+            state.nameError,
+            state.lastNameError,
+            state.emailError,
+            state.userNameError,
+            state.birthdateError,
+            state.bioError,
+            state.avatarError,
+        ).any { it != null }
+
+    private fun applyProfile(profile: PlayerProfile, etag: String) {
+        _state.update {
+            it.copy(
+                name = profile.name,
+                lastName = profile.lastName,
+                email = profile.email,
+                userName = profile.userName,
+                birthdate = profile.birthdate.orEmpty(),
+                bio = profile.bio,
+                className = profile.className,
+                level = profile.level,
+                avatarUri = profile.avatarUri,
+                pendingAvatarUri = null,
+                etag = etag,
+                isEditing = false,
+                editSnapshot = null,
+            )
+        }
+    }
+
+    private fun mapThrowableMessage(throwable: Throwable): String =
+        when (val error = (throwable as? ProfileException)?.error) {
+            is ProfileError.Network -> "network"
+            is ProfileError.Conflict -> "conflict"
+            is ProfileError.PreconditionFailed -> "precondition_failed"
+            is ProfileError.Validation -> error.message
+            is ProfileError -> error.message
+            else -> throwable.message ?: "unknown"
+        }
+
+    class Factory(
+        private val profileRepository: ProfileRepository,
+        private val profileCache: ProfileCache,
+        private val avatarStorage: ProfileAvatarStorage,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
+                return ProfileViewModel(profileRepository, profileCache, avatarStorage) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel: ${modelClass.name}")
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
 
     <!-- Login: errores -->
     <string name="login_error_invalid_credentials">Usuario/email o contraseña incorrectos</string>
+    <string name="login_error_session_expired">Tu sesión expiró. Iniciá sesión de nuevo.</string>
     <string name="login_error_account_locked">Tu cuenta está bloqueada. Intenta más tarde.</string>
     <string name="login_error_bad_request">Solicitud inválida. Revisa los datos ingresados.</string>
     <string name="login_error_server">Error del servidor. Intenta más tarde.</string>
@@ -24,6 +25,8 @@
     <!-- Validación de campos -->
     <string name="field_required">Campo obligatorio</string>
     <string name="field_invalid_email">Email inválido</string>
+    <string name="field_invalid_birthdate">Usa una fecha válida en formato AAAA-MM-DD</string>
+    <string name="field_invalid_characters">Solo se permiten letras, espacios, apóstrofes y guiones</string>
     <string name="field_invalid_username_or_email">Ingresa un email o usuario válido</string>
     <string name="field_min_length">Mínimo %1$d caracteres</string>
     <string name="field_max_length">Máximo %1$d caracteres</string>
@@ -39,4 +42,40 @@
     <string name="dashboard_subtitle">Has iniciado sesión correctamente.</string>
     <string name="dashboard_session_active">Sesión activa</string>
     <string name="dashboard_logout">Cerrar sesión</string>
+
+    <!-- Profile -->
+    <string name="profile_title">Mi perfil</string>
+    <string name="profile_back">Volver</string>
+    <string name="profile_subtitle">Revisá tu información pública</string>
+    <string name="profile_edit_subtitle">Modificá los campos que quieras actualizar</string>
+    <string name="profile_edit">Editar perfil</string>
+    <string name="profile_cancel_edit">Cancelar</string>
+    <string name="profile_not_set">Sin definir</string>
+    <string name="profile_avatar_change">Cambiar avatar</string>
+    <string name="profile_avatar_hint">JPG, PNG o WebP. Máximo 2 MB.</string>
+    <string name="profile_avatar_too_large">La imagen supera el tamaño máximo</string>
+    <string name="profile_avatar_invalid_type">Formato de imagen no permitido</string>
+    <string name="profile_name_label">Nombre</string>
+    <string name="profile_last_name_label">Apellido</string>
+    <string name="profile_email_label">Email</string>
+    <string name="profile_username_label">Usuario</string>
+    <string name="profile_birthdate_label">Fecha de nacimiento</string>
+    <string name="profile_birthdate_hint">AAAA-MM-DD (opcional)</string>
+    <string name="profile_bio_label">Bio</string>
+    <string name="profile_bio_hint">Contá algo sobre vos (solo en este dispositivo por ahora)</string>
+    <string name="profile_class_label">Clase</string>
+    <string name="profile_level_label">Nivel %1$d</string>
+    <string name="profile_save">Guardar cambios</string>
+    <string name="profile_saving">Guardando…</string>
+    <string name="profile_save_success">Perfil actualizado correctamente</string>
+    <string name="profile_load_error">No se pudo cargar el perfil</string>
+    <string name="profile_error_network">Sin conexión. Revisá tu red e intentá de nuevo.</string>
+    <string name="profile_error_conflict">Ese usuario ya está en uso.</string>
+    <string name="profile_error_precondition">El perfil cambió en otro lugar. Recargá e intentá de nuevo.</string>
+    <string name="profile_retry">Reintentar</string>
+    <string name="profile_logout">Cerrar sesión</string>
+    <string name="profile_logout_confirm_title">¿Cerrar sesión?</string>
+    <string name="profile_logout_confirm_message">Se cerrará tu sesión en este dispositivo. Tendrás que volver a iniciar sesión para entrar.</string>
+    <string name="profile_logout_confirm">Cerrar sesión</string>
+    <string name="cd_profile_avatar">Avatar de perfil</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="profile_avatar_hint">JPG, PNG o WebP. Máximo 2 MB.</string>
     <string name="profile_avatar_too_large">La imagen supera el tamaño máximo</string>
     <string name="profile_avatar_invalid_type">Formato de imagen no permitido</string>
+    <string name="profile_avatar_persist_failed">No se pudo guardar la imagen. Intentá de nuevo.</string>
     <string name="profile_name_label">Nombre</string>
     <string name="profile_last_name_label">Apellido</string>
     <string name="profile_email_label">Email</string>

--- a/app/src/test/java/com/example/leveluplife/data/network/interceptor/AuthInterceptorTest.kt
+++ b/app/src/test/java/com/example/leveluplife/data/network/interceptor/AuthInterceptorTest.kt
@@ -2,6 +2,7 @@ package com.example.leveluplife.data.network.interceptor
 
 import com.example.leveluplife.data.auth.FakeTokenStore
 import com.example.leveluplife.data.auth.SessionEvents
+import com.example.leveluplife.data.network.ApiRoutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -11,6 +12,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -86,6 +88,29 @@ class AuthInterceptorTest {
         job.cancel()
 
         assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `respuesta 401 en login con path PascalCase no emite sesión expirada`() = runTest {
+        store.saveTokens("expired-token", null)
+        mockServer.enqueue(MockResponse().setResponseCode(401))
+        val events = mutableListOf<Unit>()
+        val job = launch { sessionEvents.expired.collect { events.add(Unit) } }
+
+        client().newCall(Request.Builder().url(mockServer.url("/api/Auth/Login")).build())
+            .execute().close()
+
+        testScheduler.advanceUntilIdle()
+        job.cancel()
+
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `ApiRoutes reconoce login sin importar mayúsculas`() {
+        assertTrue(ApiRoutes.isLoginRequest("/api/auth/login"))
+        assertTrue(ApiRoutes.isLoginRequest("/api/Auth/Login"))
+        assertFalse(ApiRoutes.isLoginRequest("/api/Player/profile"))
     }
 
     @Test

--- a/app/src/test/java/com/example/leveluplife/data/network/interceptor/AuthInterceptorTest.kt
+++ b/app/src/test/java/com/example/leveluplife/data/network/interceptor/AuthInterceptorTest.kt
@@ -1,6 +1,10 @@
 package com.example.leveluplife.data.network.interceptor
 
 import com.example.leveluplife.data.auth.FakeTokenStore
+import com.example.leveluplife.data.auth.SessionEvents
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -8,18 +12,21 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AuthInterceptorTest {
 
     private val mockServer = MockWebServer()
     private val store = FakeTokenStore()
+    private val sessionEvents = SessionEvents()
 
     @After
     fun tearDown() = mockServer.shutdown()
 
     private fun client() = OkHttpClient.Builder()
-        .addInterceptor(AuthInterceptor(store))
+        .addInterceptor(AuthInterceptor(store, sessionEvents))
         .build()
 
     // Scenario: Authorization header attached
@@ -48,15 +55,37 @@ class AuthInterceptorTest {
     }
 
     @Test
-    fun `respuesta 401 limpia el token del almacenamiento`() {
+    fun `respuesta 401 en endpoint autenticado limpia el token y emite sesión expirada`() = runTest {
         store.saveTokens("expired-token", null)
         mockServer.enqueue(MockResponse().setResponseCode(401))
+        val events = mutableListOf<Unit>()
+        val job = launch { sessionEvents.expired.collect { events.add(Unit) } }
 
         client().newCall(Request.Builder().url(mockServer.url("/api/resource")).build())
             .execute().close()
 
+        testScheduler.advanceUntilIdle()
+        job.cancel()
+
         assertNull(store.accessToken())
         assertEquals(1, store.clearCallCount)
+        assertEquals(1, events.size)
+    }
+
+    @Test
+    fun `respuesta 401 en login no emite sesión expirada`() = runTest {
+        store.saveTokens("expired-token", null)
+        mockServer.enqueue(MockResponse().setResponseCode(401))
+        val events = mutableListOf<Unit>()
+        val job = launch { sessionEvents.expired.collect { events.add(Unit) } }
+
+        client().newCall(Request.Builder().url(mockServer.url("/api/auth/login")).build())
+            .execute().close()
+
+        testScheduler.advanceUntilIdle()
+        job.cancel()
+
+        assertTrue(events.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/example/leveluplife/domain/validation/ProfileValidatorsTest.kt
+++ b/app/src/test/java/com/example/leveluplife/domain/validation/ProfileValidatorsTest.kt
@@ -1,0 +1,138 @@
+package com.example.leveluplife.domain.validation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AvatarValidatorTest {
+
+    @Test
+    fun `valid jpeg within size passes`() {
+        assertNull(AvatarValidator.validate("image/jpeg", 1024))
+    }
+
+    @Test
+    fun `file too large fails`() {
+        assertEquals(
+            AvatarValidationError.TooLarge,
+            AvatarValidator.validate("image/png", AvatarValidator.MAX_BYTES + 1),
+        )
+    }
+
+    @Test
+    fun `unsupported mime fails`() {
+        assertEquals(
+            AvatarValidationError.UnsupportedType,
+            AvatarValidator.validate("image/gif", 1024),
+        )
+    }
+}
+
+class ProfileInputSanitizerTest {
+
+    @Test
+    fun `sanitizePersonName collapses spaces and strips control chars`() {
+        val result = ProfileInputSanitizer.sanitizePersonName("  Aaron\u0001  Test  ")
+        assertEquals(" Aaron Test ", result)
+    }
+
+    @Test
+    fun `sanitizeEmail removes spaces`() {
+        assertEquals("aaron@test.com", ProfileInputSanitizer.sanitizeEmail(" aaron @test.com "))
+    }
+
+    @Test
+    fun `sanitizeUserName removes invalid chars`() {
+        assertEquals("aaron.dev_1", ProfileInputSanitizer.sanitizeUserName(" aaron dev!@#._1 "))
+    }
+
+    @Test
+    fun `sanitizeBirthdate keeps digits and hyphens only`() {
+        assertEquals("2000-01-15", ProfileInputSanitizer.sanitizeBirthdate("20abc00/01-15xyz"))
+    }
+
+    @Test
+    fun `sanitizeBio caps length`() {
+        val longBio = "a".repeat(ProfileValidators.BIO_MAX + 10)
+        assertEquals(ProfileValidators.BIO_MAX, ProfileInputSanitizer.sanitizeBio(longBio).length)
+    }
+}
+
+class ProfileValidatorsTest {
+
+    @Test
+    fun `validateName rejects empty`() {
+        assertTrue(ProfileValidators.validateName("") is FieldError.Required)
+    }
+
+    @Test
+    fun `validateName rejects digits`() {
+        assertTrue(ProfileValidators.validateName("Aaron1") is FieldError.InvalidCharacters)
+    }
+
+    @Test
+    fun `validateName accepts accented letters`() {
+        assertNull(ProfileValidators.validateName("María"))
+    }
+
+    @Test
+    fun `validateEmail rejects invalid format`() {
+        assertTrue(ProfileValidators.validateEmail("not-an-email") is FieldError.InvalidEmail)
+    }
+
+    @Test
+    fun `validateEmail accepts valid email`() {
+        assertNull(ProfileValidators.validateEmail("aaron@test.com"))
+    }
+
+    @Test
+    fun `validateUserName rejects too short`() {
+        assertTrue(ProfileValidators.validateUserName("ab") is FieldError.TooShort)
+    }
+
+    @Test
+    fun `validateUserName rejects leading dot`() {
+        assertTrue(ProfileValidators.validateUserName(".aarontest") is FieldError.InvalidUserNameOrEmail)
+    }
+
+    @Test
+    fun `validateBirthdate accepts valid date`() {
+        assertNull(ProfileValidators.validateBirthdate("2000-01-15"))
+    }
+
+    @Test
+    fun `validateBirthdate rejects invalid format`() {
+        assertTrue(ProfileValidators.validateBirthdate("15-01-2000") is FieldError.InvalidBirthdate)
+    }
+
+    @Test
+    fun `validateBirthdate rejects impossible date`() {
+        assertTrue(ProfileValidators.validateBirthdate("2000-02-31") is FieldError.InvalidBirthdate)
+    }
+
+    @Test
+    fun `validateBirthdate rejects future date`() {
+        assertTrue(ProfileValidators.validateBirthdate("2099-12-31") is FieldError.InvalidBirthdate)
+    }
+
+    @Test
+    fun `validateBio rejects too long`() {
+        val longBio = "a".repeat(ProfileValidators.BIO_MAX + 1)
+        assertTrue(ProfileValidators.validateBio(longBio) is FieldError.TooLong)
+    }
+
+    @Test
+    fun `validateAll returns multiple errors`() {
+        val errors = ProfileValidators.validateAll(
+            ProfileFormValues(
+                name = "",
+                email = "bad",
+                userName = "x",
+            ),
+        )
+        assertTrue(errors.containsKey(ProfileFieldKey.NAME))
+        assertTrue(errors.containsKey(ProfileFieldKey.EMAIL))
+        assertTrue(errors.containsKey(ProfileFieldKey.USER_NAME))
+    }
+}

--- a/app/src/test/java/com/example/leveluplife/ui/profile/ProfileTestFixtures.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/profile/ProfileTestFixtures.kt
@@ -1,0 +1,107 @@
+package com.example.leveluplife.ui.profile
+
+import com.example.leveluplife.data.player.PlayerProfile
+import com.example.leveluplife.data.player.ProfileAvatarStorage
+import com.example.leveluplife.data.player.ProfileCache
+import com.example.leveluplife.data.player.ProfileError
+import com.example.leveluplife.data.player.ProfileException
+import com.example.leveluplife.data.player.ProfileFetchResult
+import com.example.leveluplife.data.player.ProfileRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeProfileRepository(
+    private var fetchResult: Result<ProfileFetchResult> = Result.failure(Exception("not configured")),
+    private var updateResult: Result<PlayerProfile> = Result.failure(Exception("not configured")),
+) : ProfileRepository {
+    var fetchCalls = 0
+        private set
+    var updateCalls = 0
+        private set
+    var lastUpdateEtag: String? = null
+        private set
+
+    fun setFetchResult(result: Result<ProfileFetchResult>) {
+        fetchResult = result
+    }
+
+    fun setUpdateResult(result: Result<PlayerProfile>) {
+        updateResult = result
+    }
+
+    override suspend fun fetchProfile(): Result<ProfileFetchResult> {
+        fetchCalls++
+        return fetchResult
+    }
+
+    override suspend fun updateProfile(
+        etag: String,
+        name: String,
+        lastName: String,
+        email: String,
+        birthdate: String?,
+        userName: String,
+    ): Result<PlayerProfile> {
+        updateCalls++
+        lastUpdateEtag = etag
+        return updateResult
+    }
+}
+
+class FakeProfileCache(
+    initial: PlayerProfile? = null,
+    private var etag: String? = "\"etag-1\"",
+) : ProfileCache {
+    private val _profile = MutableStateFlow(initial)
+    override val profile: StateFlow<PlayerProfile?> = _profile
+
+    override suspend fun loadPersisted() = Unit
+
+    override suspend fun update(profile: PlayerProfile, etag: String?) {
+        if (etag != null) this.etag = etag
+        _profile.value = profile
+    }
+
+    override suspend fun updateLocalExtras(avatarUri: String?, bio: String) {
+        val current = _profile.value ?: return
+        _profile.value = current.copy(avatarUri = avatarUri, bio = bio)
+    }
+
+    override fun currentEtag(): String? = etag
+}
+
+fun sampleProfile() = PlayerProfile(
+    playerUserId = "1",
+    userName = "aarontest",
+    level = 3,
+    classId = 1,
+    className = "Warrior",
+    name = "Aaron",
+    lastName = "Test",
+    email = "aarontest@leveluplife.com",
+    birthdate = "2000-01-15",
+    bio = "Hola",
+)
+
+fun validationException() = ProfileException(
+    ProfileError.Validation(
+        message = "Validation failed",
+        fieldErrors = mapOf(
+            com.example.leveluplife.data.player.ProfileField.Email to "Invalid email",
+        ),
+    ),
+)
+
+class FakeProfileAvatarStorage(
+    private val persistedUri: String = "file:///fake/profile_avatar.jpg",
+) : ProfileAvatarStorage {
+    var persistCalls = 0
+        private set
+
+    override suspend fun persistFromPickerUri(sourceUri: String, mimeType: String?): String? {
+        persistCalls++
+        return persistedUri
+    }
+
+    override fun resolveDisplayUri(storedUri: String?): String? = storedUri ?: persistedUri
+}

--- a/app/src/test/java/com/example/leveluplife/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/profile/ProfileViewModelTest.kt
@@ -2,6 +2,7 @@ package com.example.leveluplife.ui.profile
 
 import com.example.leveluplife.data.player.ProfileFetchResult
 import com.example.leveluplife.domain.validation.AvatarValidator
+import com.example.leveluplife.domain.validation.AvatarValidationError
 import com.example.leveluplife.domain.validation.FieldError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -112,7 +113,7 @@ class ProfileViewModelTest {
             sizeBytes = AvatarValidator.MAX_BYTES + 1,
         )
 
-        assertEquals(FieldError.TooLong(AvatarValidator.MAX_BYTES), vm.state.value.avatarError)
+        assertEquals(AvatarValidationError.TooLarge, vm.state.value.avatarError)
         assertNull(vm.state.value.avatarUri)
     }
 

--- a/app/src/test/java/com/example/leveluplife/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/profile/ProfileViewModelTest.kt
@@ -1,0 +1,162 @@
+package com.example.leveluplife.ui.profile
+
+import com.example.leveluplife.data.player.ProfileFetchResult
+import com.example.leveluplife.domain.validation.AvatarValidator
+import com.example.leveluplife.domain.validation.FieldError
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `load profile populates form fields`() = runTest(testDispatcher) {
+        val profile = sampleProfile()
+        val repo = FakeProfileRepository(
+            fetchResult = Result.success(ProfileFetchResult(profile, "\"etag-1\"")),
+        )
+        val cache = FakeProfileCache(initial = profile, etag = "\"etag-1\"")
+        val vm = ProfileViewModel(repo, cache, FakeProfileAvatarStorage())
+
+        advanceUntilIdle()
+
+        assertEquals("Aaron", vm.state.value.name)
+        assertEquals("aarontest", vm.state.value.userName)
+        assertFalse(vm.state.value.isLoading)
+        assertEquals(1, repo.fetchCalls)
+    }
+
+    @Test
+    fun `start editing enables form and cancel restores snapshot`() = runTest(testDispatcher) {
+        val profile = sampleProfile()
+        val repo = FakeProfileRepository(
+            fetchResult = Result.success(ProfileFetchResult(profile, "\"etag-1\"")),
+        )
+        val vm = ProfileViewModel(repo, FakeProfileCache(initial = profile), FakeProfileAvatarStorage())
+        advanceUntilIdle()
+
+        vm.onStartEditing()
+        vm.onNameChange("Changed")
+        assertTrue(vm.state.value.isEditing)
+        assertEquals("Changed", vm.state.value.name)
+
+        vm.onCancelEditing()
+        assertFalse(vm.state.value.isEditing)
+        assertEquals("Aaron", vm.state.value.name)
+    }
+
+    @Test
+    fun `username change sanitizes spaces and invalid chars`() = runTest(testDispatcher) {
+        val profile = sampleProfile()
+        val repo = FakeProfileRepository(
+            fetchResult = Result.success(ProfileFetchResult(profile, "\"etag-1\"")),
+        )
+        val vm = ProfileViewModel(repo, FakeProfileCache(initial = profile), FakeProfileAvatarStorage())
+        advanceUntilIdle()
+
+        vm.onStartEditing()
+        vm.onUserNameChange(" aaron dev! ")
+
+        assertEquals("aarondev", vm.state.value.userName)
+    }
+
+    @Test
+    fun `submit with invalid fields does not call API`() = runTest(testDispatcher) {
+        val repo = FakeProfileRepository(
+            fetchResult = Result.success(ProfileFetchResult(sampleProfile(), "\"etag-1\"")),
+        )
+        val vm = ProfileViewModel(repo, FakeProfileCache(initial = sampleProfile()), FakeProfileAvatarStorage())
+        advanceUntilIdle()
+
+        vm.onStartEditing()
+        vm.onNameChange("")
+        vm.onSubmit()
+        advanceUntilIdle()
+
+        assertEquals(FieldError.Required, vm.state.value.nameError)
+        assertEquals(0, repo.updateCalls)
+    }
+
+    @Test
+    fun `avatar too large blocks selection`() = runTest(testDispatcher) {
+        val vm = ProfileViewModel(FakeProfileRepository(), FakeProfileCache(), FakeProfileAvatarStorage())
+        advanceUntilIdle()
+
+        vm.onAvatarSelected(
+            uri = "content://image/1",
+            mimeType = "image/jpeg",
+            sizeBytes = AvatarValidator.MAX_BYTES + 1,
+        )
+
+        assertEquals(FieldError.TooLong(AvatarValidator.MAX_BYTES), vm.state.value.avatarError)
+        assertNull(vm.state.value.avatarUri)
+    }
+
+    @Test
+    fun `successful update emits saved event and updates cache`() = runTest(testDispatcher) {
+        val profile = sampleProfile()
+        val updated = profile.copy(name = "Aaron Updated")
+        val repo = FakeProfileRepository(
+            fetchResult = Result.success(ProfileFetchResult(profile, "\"etag-1\"")),
+            updateResult = Result.success(updated),
+        )
+        val cache = FakeProfileCache(initial = profile, etag = "\"etag-1\"")
+        val vm = ProfileViewModel(repo, cache, FakeProfileAvatarStorage())
+        advanceUntilIdle()
+
+        vm.onStartEditing()
+        vm.onNameChange("Aaron Updated")
+        vm.onSubmit()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.profileSaved)
+        assertFalse(vm.state.value.isEditing)
+        assertEquals(1, repo.updateCalls)
+        assertEquals("Aaron Updated", cache.profile.value?.name)
+    }
+
+    @Test
+    fun `server validation error shows inline field error without updating cache`() = runTest(testDispatcher) {
+        val profile = sampleProfile()
+        val repo = FakeProfileRepository(
+            fetchResult = Result.success(ProfileFetchResult(profile, "\"etag-1\"")),
+            updateResult = Result.failure(validationException()),
+        )
+        val cache = FakeProfileCache(initial = profile, etag = "\"etag-1\"")
+        val vm = ProfileViewModel(repo, cache, FakeProfileAvatarStorage())
+        advanceUntilIdle()
+
+        vm.onStartEditing()
+        vm.onSubmit()
+        advanceUntilIdle()
+
+        assertEquals("Invalid email", vm.state.value.serverFieldErrors[ProfileFormField.EMAIL])
+        assertEquals("Aaron", cache.profile.value?.name)
+        assertFalse(vm.state.value.profileSaved)
+        assertEquals(1, repo.updateCalls)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ coroutines = "1.9.0"
 turbine = "1.2.0"
 mockwebserver = "4.12.0"
 archCoreTesting = "2.2.0"
+coil = "2.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -67,6 +68,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "archCoreTesting" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

This PR implements the player profile view/edit flow for Issue #5, integrating `GET /api/Player/profile` and `PUT /api/Player/update` with `ETag` / `If-Match`.

It adds a Profile screen (view + edit modes), field sanitization/validation, local avatar persistence, offline cache fallback, logout confirmation, and automatic redirect to Login when the session expires (`401`).

---

## 🎯 Purpose

Players need to view and update their profile from the Android app.

This change is necessary to close the frontend gap for Issue #5: load profile data from the backend, edit safely with concurrency control, validate input before save, and handle expired sessions by returning the user to Login.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

Explain the testing process:

1. Logged in on physical device with backend on `http://<LAN_IP>:5147`
2. Opened profile from Home (person icon) and verified view mode
3. Edited profile fields and saved successfully
4. Selected avatar and confirmed it persists after re-entering the screen
5. Tested offline with cached profile (no blocking error dialog)
6. Simulated expired session (`401`) and verified redirect to Login
7. Ran unit tests: `ProfileViewModelTest`, `ProfileValidatorsTest`, `AuthInterceptorTest`

---

## 📸 Screenshots (if applicable)

| Step | Screen | Image |
|------|--------|-------|
| 1 | Profile — view|<img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/4736e50b-48a8-4f87-a858-b82635b49961" />|
| 2 | Profile — edition| <img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/36c0f5c3-20f0-4d54-a037-0d676b6187f1" />|
| 3 | Close sesion| <img width="1080" height="2239" alt="image" src="https://github.com/user-attachments/assets/7ffc989c-5646-4e08-8130-098ba699013b" />|

---

## 🚀 Deployment Notes (if needed)

- `api.host` in `local.properties` is per-developer and is not committed
- Backend must run with `dotnet run --urls "http://0.0.0.0:5147"`
- Avatar and bio are stored locally (backend does not expose those fields yet)

---

## ✅ Checklist

Before requesting a review, please confirm:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #5
Linked to #7
