### PR TITLE
Feature/25 frontend update habit task 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ val localProps = Properties().apply {
     val f = rootProject.file("local.properties")
     if (f.exists()) f.inputStream().use { load(it) }
 }
-val apiHost: String = localProps.getProperty("api.host", "localhost:5223")
+val apiHost: String = localProps.getProperty("api.host", "localhost:5147")
 val apiScheme: String = localProps.getProperty("api.scheme", "http")
 
 android {

--- a/app/src/main/java/com/example/leveluplife/AppContainer.kt
+++ b/app/src/main/java/com/example/leveluplife/AppContainer.kt
@@ -1,6 +1,8 @@
 package com.example.leveluplife
 
 import android.content.Context
+import android.util.Log
+import com.example.leveluplife.BuildConfig
 import com.example.leveluplife.data.auth.AuthRepository
 import com.example.leveluplife.data.auth.DefaultAuthRepository
 import com.example.leveluplife.data.auth.EncryptedTokenStore
@@ -34,6 +36,10 @@ import kotlinx.coroutines.Dispatchers
 class AppContainer(applicationContext: Context) {
 
     private val appContext = applicationContext.applicationContext
+
+    companion object {
+        private const val TAG = "LevelUpLife"
+    }
     private val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     val themePreferences: ThemePreferences = ThemePreferences(appContext)
@@ -47,7 +53,11 @@ class AppContainer(applicationContext: Context) {
 
     private val okHttp = NetworkModule.provideOkHttp(tokenStore, sessionEvents)
     private val retrofit by lazy {
-        NetworkModule.provideRetrofit(okHttp, hostProvider.resolveBaseUrl())
+        val baseUrl = hostProvider.resolveBaseUrl()
+        if (BuildConfig.DEBUG) {
+            Log.i(TAG, "API base URL: $baseUrl (BuildConfig host=${BuildConfig.API_HOST})")
+        }
+        NetworkModule.provideRetrofit(okHttp, baseUrl)
     }
     private val authApi: AuthApi by lazy { NetworkModule.provideAuthApi(retrofit) }
     private val habitsApi: HabitsApi by lazy { NetworkModule.provideHabitsApi(retrofit) }

--- a/app/src/main/java/com/example/leveluplife/data/habits/HabitTaskApiErrorParser.kt
+++ b/app/src/main/java/com/example/leveluplife/data/habits/HabitTaskApiErrorParser.kt
@@ -45,10 +45,11 @@ object HabitTaskApiErrorParser {
         }
 
         val fieldErrors = mapServerErrors(errorsNode)
-        val summary = if (fieldErrors.hasErrors) {
-            "Revisa los campos marcados."
-        } else {
-            root["title"]?.asStringOrNull() ?: "Datos inválidos."
+        val firstMessage = firstErrorMessage(errorsNode)
+        val summary = when {
+            fieldErrors.hasErrors -> "Revisa los campos marcados."
+            firstMessage != null -> firstMessage
+            else -> root["title"]?.asStringOrNull() ?: "Datos inválidos."
         }
         return ParsedApiError(summary = summary, fieldErrors = fieldErrors)
     }
@@ -92,8 +93,20 @@ object HabitTaskApiErrorParser {
                 "measurementUnit",
             ),
             evidence = mapField("evidence", "Evidence"),
+            timerSeconds = mapField(
+                "timerCriteria",
+                "TimerCriteria",
+                "timerCriteria.numSecondsDefined",
+                "TimerCriteria.NUM_SECONDS_DEFINED",
+                "TimerCriteria.NumSecondsDefined",
+            ),
         )
     }
+
+    private fun firstErrorMessage(errors: JsonObject): String? =
+        errors.values
+            .flatMap { it.toMessageList() }
+            .firstOrNull { it.isNotBlank() }
 
     private fun JsonElement.toMessageList(): List<String> = when (this) {
         is JsonArray -> mapNotNull { (it as? JsonPrimitive)?.asStringOrNull() }

--- a/app/src/main/java/com/example/leveluplife/data/habits/HabitTaskRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/habits/HabitTaskRepository.kt
@@ -7,23 +7,44 @@ import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
+class HabitTaskConflictFailure(
+    override val message: String,
+) : Exception(message)
+
 interface HabitTaskRepository {
     suspend fun createHabitTask(request: CreateHabitTaskRequest): Result<HabitTaskDto>
+    suspend fun getHabitTask(taskId: Int): Result<HabitTaskDto>
+    suspend fun updateHabitTask(taskId: Int, request: CreateHabitTaskRequest): Result<HabitTaskDto>
 }
 
 class DefaultHabitTaskRepository(
     private val api: HabitTasksApi,
 ) : HabitTaskRepository {
 
-    override suspend fun createHabitTask(request: CreateHabitTaskRequest): Result<HabitTaskDto> = try {
-        val response = api.createHabitTask(request)
+    override suspend fun createHabitTask(request: CreateHabitTaskRequest): Result<HabitTaskDto> =
+        execute { api.createHabitTask(request) }
+
+    override suspend fun getHabitTask(taskId: Int): Result<HabitTaskDto> =
+        execute { api.getHabitTask(taskId) }
+
+    override suspend fun updateHabitTask(
+        taskId: Int,
+        request: CreateHabitTaskRequest,
+    ): Result<HabitTaskDto> = execute { api.updateHabitTask(taskId, request) }
+
+    private suspend fun execute(
+        call: suspend () -> retrofit2.Response<HabitTaskDto>,
+    ): Result<HabitTaskDto> = try {
+        val response = call()
         when {
             response.isSuccessful -> Result.success(requireNotNull(response.body()))
             response.code() == 409 -> Result.failure(
-                Exception("Este hábito ya tiene una tarea activa. Desactívala antes de crear otra."),
+                HabitTaskConflictFailure(
+                    "La tarea cambió en otro lugar. Recargá los datos e intentá de nuevo.",
+                ),
             )
-            response.code() == 404 -> Result.failure(Exception("Hábito no encontrado o inactivo."))
-            response.code() == 403 -> Result.failure(Exception("No tienes permiso para crear tareas en este hábito."))
+            response.code() == 404 -> Result.failure(Exception("Tarea no encontrada o inactiva."))
+            response.code() == 403 -> Result.failure(Exception("No tienes permiso para modificar esta tarea."))
             response.code() == 401 -> Result.failure(Exception("Sesión expirada. Vuelve a iniciar sesión."))
             response.code() == 400 -> {
                 val body = runCatching { response.errorBody()?.string() }.getOrNull()

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitTasksApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitTasksApi.kt
@@ -4,9 +4,21 @@ import com.example.leveluplife.data.network.dto.CreateHabitTaskRequest
 import com.example.leveluplife.data.network.dto.HabitTaskDto
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
 
 interface HabitTasksApi {
     @POST("api/habit-tasks")
     suspend fun createHabitTask(@Body body: CreateHabitTaskRequest): Response<HabitTaskDto>
+
+    @GET("api/habit-tasks/{taskId}")
+    suspend fun getHabitTask(@Path("taskId") taskId: Int): Response<HabitTaskDto>
+
+    @PUT("api/habit-tasks/{taskId}")
+    suspend fun updateHabitTask(
+        @Path("taskId") taskId: Int,
+        @Body body: CreateHabitTaskRequest,
+    ): Response<HabitTaskDto>
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
@@ -8,13 +8,13 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface HabitsApi {
-    @GET("api/habits/active")
+    @GET("api/Habits/active")
     suspend fun getActiveHabits(
         @Query("pageNumber") pageNumber: Int,
         @Query("pageSize") pageSize: Int,
     ): Response<HabitsPageResponse>
 
-    /** Detalle del hábito con tasks[] y repetitionCriteria (issue #24, requiere JWT). */
+    /** Detalle del hábito con tasks[] (repetitionCriteria, timerCriteria). Requiere JWT. */
     @GET("api/Habits/{id}")
     suspend fun getHabitById(@Path("id") id: Int): Response<HabitDto>
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
@@ -14,7 +14,7 @@ interface HabitsApi {
         @Query("pageSize") pageSize: Int,
     ): Response<HabitsPageResponse>
 
-    /** Detalle del hábito con tasks[] (repetitionCriteria, timerCriteria). Requiere JWT. */
+    /** Habit detail with tasks[] (repetitionCriteria, timerCriteria). Requires JWT. */
     @GET("api/Habits/{id}")
     suspend fun getHabitById(@Path("id") id: Int): Response<HabitDto>
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/HostProvider.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HostProvider.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.runBlocking
 /**
  * Resuelve el host base del backend tomando en cuenta:
  *  1. Override runtime (DataStore debug) si se ha definido en builds debug.
- *  2. BuildConfig.API_HOST (default `localhost:5223` o el valor de local.properties).
+ *  2. BuildConfig.API_HOST (default `localhost:5147` o el valor de local.properties).
  *  3. Si el host efectivo apunta a `localhost` y se ejecuta en emulador,
  *     se reemplaza automáticamente por `10.0.2.2` (IP del host del emulador).
  */
@@ -28,13 +28,34 @@ class HostProvider(
         val configuredHost = overrideHost?.takeUnless { it.isBlank() } ?: BuildConfig.API_HOST
         val configuredScheme = overrideScheme?.takeUnless { it.isBlank() } ?: BuildConfig.API_SCHEME
 
-        val finalHost = if (configuredHost.startsWith("localhost") && isProbablyEmulator()) {
-            configuredHost.replaceFirst("localhost", "10.0.2.2")
-        } else {
-            configuredHost
-        }
+        val finalHost = resolveHostForDevice(configuredHost)
         return configuredScheme to finalHost
     }
+
+    /**
+     * En emulador, `localhost` y las IPs LAN del PC (p. ej. 192.168.x.x) no alcanzan
+     * el backend del host; hay que usar el alias `10.0.2.2` conservando el puerto.
+     */
+    private fun resolveHostForDevice(configuredHost: String): String {
+        if (!isProbablyEmulator()) return configuredHost
+
+        return when {
+            configuredHost.startsWith("localhost") ->
+                configuredHost.replaceFirst("localhost", EMULATOR_HOST_ALIAS)
+            isPrivateLanHost(configuredHost) ->
+                "$EMULATOR_HOST_ALIAS:${extractPort(configuredHost)}"
+            else -> configuredHost
+        }
+    }
+
+    private fun isPrivateLanHost(host: String): Boolean {
+        val address = host.substringBefore(':')
+        if (address.startsWith("192.168.") || address.startsWith("10.")) return true
+        return PRIVATE_172_LAN.matches(address)
+    }
+
+    private fun extractPort(host: String): String =
+        host.substringAfter(':', DEFAULT_PORT)
 
     private fun isProbablyEmulator(): Boolean {
         val fp = Build.FINGERPRINT?.lowercase().orEmpty()
@@ -48,5 +69,11 @@ class HostProvider(
             product.contains("sdk") ||
             hardware.contains("goldfish") ||
             hardware.contains("ranchu")
+    }
+
+    companion object {
+        private const val EMULATOR_HOST_ALIAS = "10.0.2.2"
+        private const val DEFAULT_PORT = "5147"
+        private val PRIVATE_172_LAN = Regex("""172\.(1[6-9]|2\d|3[01])\.\d+\.\d+""")
     }
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/HostProvider.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HostProvider.kt
@@ -7,11 +7,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 /**
- * Resuelve el host base del backend tomando en cuenta:
- *  1. Override runtime (DataStore debug) si se ha definido en builds debug.
- *  2. BuildConfig.API_HOST (default `localhost:5147` o el valor de local.properties).
- *  3. Si el host efectivo apunta a `localhost` y se ejecuta en emulador,
- *     se reemplaza automáticamente por `10.0.2.2` (IP del host del emulador).
+ * Resolves the backend base host taking into account:
+ *  1. Runtime override (DataStore debug) when set in debug builds.
+ *  2. BuildConfig.API_HOST (default `localhost:5147` or the local.properties value).
+ *  3. When the effective host points to `localhost` on an emulator,
+ *     it is automatically replaced with `10.0.2.2` (the emulator host IP).
  */
 class HostProvider(
     private val debugPrefs: DebugApiPreferences,
@@ -33,8 +33,8 @@ class HostProvider(
     }
 
     /**
-     * En emulador, `localhost` y las IPs LAN del PC (p. ej. 192.168.x.x) no alcanzan
-     * el backend del host; hay que usar el alias `10.0.2.2` conservando el puerto.
+     * On the emulator, `localhost` and the PC LAN IPs (e.g. 192.168.x.x) cannot
+     * reach the host backend; use the `10.0.2.2` alias while preserving the port.
      */
     private fun resolveHostForDevice(configuredHost: String): String {
         if (!isProbablyEmulator()) return configuredHost

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/HabitTaskDtos.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/HabitTaskDtos.kt
@@ -1,5 +1,6 @@
 package com.example.leveluplife.data.network.dto
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -8,6 +9,19 @@ data class CreateRepetitionCriteriaRequest(
     val measurementUnit: String,
     val isPartialAllowed: Boolean = false,
     val isActive: Boolean = true,
+)
+
+/** Nombres alineados con CreateTimerCriteriaRequestDto del backend. */
+@Serializable
+data class CreateTimerCriteriaRequest(
+    @SerialName("NUM_SECONDS_DEFINED")
+    val numSecondsDefined: Int,
+    @SerialName("NUM_SECONDS_LONG")
+    val numSecondsLong: Int? = null,
+    @SerialName("TYPE_PAUSE_IS_ALLOWED")
+    val typePauseIsAllowed: Boolean,
+    @SerialName("STATUS_TIMER_CRITERIA_IS_ACTIVE")
+    val statusTimerCriteriaIsActive: Boolean = true,
 )
 
 @Serializable
@@ -27,6 +41,7 @@ data class CreateHabitTaskRequest(
     val completionCriteria: String,
     val evidence: String? = null,
     val repetitionCriteria: CreateRepetitionCriteriaRequest? = null,
+    val timerCriteria: CreateTimerCriteriaRequest? = null,
 )
 
 @Serializable
@@ -51,6 +66,16 @@ data class RepetitionCriteriaDto(
 }
 
 @Serializable
+data class TimerCriteriaDto(
+    val id: Int = 0,
+    val habitTaskId: Int = 0,
+    val numSecondsDefined: Int = 0,
+    val numSecondsLong: Int? = null,
+    val typePauseIsAllowed: Boolean = false,
+    val statusTimerCriteriaIsActive: Boolean = true,
+)
+
+@Serializable
 data class HabitTaskDto(
     val id: Int,
     val habitId: Int = 0,
@@ -69,4 +94,5 @@ data class HabitTaskDto(
     val completionCriteria: String = "REPETITIONS",
     val evidence: String? = null,
     val repetitionCriteria: RepetitionCriteriaDto? = null,
+    val timerCriteria: TimerCriteriaDto? = null,
 )

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/HabitTaskDtos.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/HabitTaskDtos.kt
@@ -11,7 +11,7 @@ data class CreateRepetitionCriteriaRequest(
     val isActive: Boolean = true,
 )
 
-/** Nombres alineados con CreateTimerCriteriaRequestDto del backend. */
+/** Names aligned with the backend CreateTimerCriteriaRequestDto. */
 @Serializable
 data class CreateTimerCriteriaRequest(
     @SerialName("NUM_SECONDS_DEFINED")

--- a/app/src/main/java/com/example/leveluplife/domain/validation/HabitTaskValidators.kt
+++ b/app/src/main/java/com/example/leveluplife/domain/validation/HabitTaskValidators.kt
@@ -1,14 +1,23 @@
 package com.example.leveluplife.domain.validation
 
+import java.time.LocalDate
+
 sealed class HabitTaskFieldError {
     object Required : HabitTaskFieldError()
     data class TooShort(val min: Int) : HabitTaskFieldError()
     data class TooLong(val max: Int) : HabitTaskFieldError()
     object InvalidNumber : HabitTaskFieldError()
     object InvalidDate : HabitTaskFieldError()
+    object PastDate : HabitTaskFieldError()
+    object InvalidOption : HabitTaskFieldError()
     object CriteriaRequired : HabitTaskFieldError()
     object EvidenceRequired : HabitTaskFieldError()
 }
+
+data class HabitTaskValidationOptions(
+    val today: LocalDate = LocalDate.now(),
+    val preservedStartDate: String? = null,
+)
 
 data class HabitTaskFormInput(
     val habitId: Int?,
@@ -24,6 +33,7 @@ data class HabitTaskFormInput(
     val measurementUnit: String?,
     val evidence: String?,
     val isPartialAllowed: Boolean,
+    val timerSecondsDefined: String,
 )
 
 data class HabitTaskFormErrors(
@@ -38,6 +48,7 @@ data class HabitTaskFormErrors(
     val repetitions: HabitTaskFieldError? = null,
     val measurementUnit: HabitTaskFieldError? = null,
     val evidence: HabitTaskFieldError? = null,
+    val timerSeconds: HabitTaskFieldError? = null,
 ) {
     val hasErrors: Boolean
         get() = listOfNotNull(
@@ -52,6 +63,7 @@ data class HabitTaskFormErrors(
             repetitions,
             measurementUnit,
             evidence,
+            timerSeconds,
         ).isNotEmpty()
 }
 
@@ -59,20 +71,36 @@ object HabitTaskValidators {
 
     const val TITLE_MIN = 3
     const val TITLE_MAX = 100
+    const val DESCRIPTION_MAX = 500
+    const val PERIOD_LENGTH_MAX = 9999
+    const val REPETITIONS_MAX = 99_999
+    const val TIMER_SECONDS_MAX = 86_400
+
+    val DIFFICULTIES = setOf("EASY", "MEDIUM", "HARD", "EPIC")
+    val FREQUENCIES = setOf("DAILY", "WEEKLY", "MONTHLY")
+    val PERIOD_UNITS = setOf("DAYS", "WEEKS", "MONTHS")
+    val COMPLETION_CRITERIA = setOf("REPETITIONS", "EVIDENCE", "TIMER")
+    val MEASUREMENT_UNITS = setOf("REPS", "SERIES", "KMS", "CALS")
+    val EVIDENCE_TYPES = setOf("PHOTO", "VIDEO", "HEALTH_CONNECT")
+
     private val DATE_REGEX = Regex("^\\d{4}-\\d{2}-\\d{2}$")
 
-    fun validateForm(input: HabitTaskFormInput): HabitTaskFormErrors = HabitTaskFormErrors(
+    fun validateForm(
+        input: HabitTaskFormInput,
+        options: HabitTaskValidationOptions = HabitTaskValidationOptions(),
+    ): HabitTaskFormErrors = HabitTaskFormErrors(
         habitId = validateHabitId(input.habitId),
         title = validateTitle(input.title),
-        difficulty = validateRequiredSelection(input.difficulty),
-        frequency = validateRequiredSelection(input.frequency),
+        difficulty = validateOption(input.difficulty, DIFFICULTIES),
+        frequency = validateOption(input.frequency, FREQUENCIES),
         periodLength = validatePeriodLength(input.periodLength),
-        periodUnit = validateRequiredSelection(input.periodUnit),
-        startDate = validateStartDate(input.startDate),
-        completionCriteria = validateRequiredSelection(input.completionCriteria),
+        periodUnit = validateOption(input.periodUnit, PERIOD_UNITS),
+        startDate = validateStartDate(input.startDate, options),
+        completionCriteria = validateOption(input.completionCriteria, COMPLETION_CRITERIA),
         repetitions = validateRepetitions(input),
         measurementUnit = validateMeasurementUnit(input),
         evidence = validateEvidence(input),
+        timerSeconds = validateTimerSeconds(input),
     )
 
     fun validateHabitId(habitId: Int?): HabitTaskFieldError? =
@@ -88,42 +116,73 @@ object HabitTaskValidators {
         }
     }
 
-    fun validateRequiredSelection(value: String?): HabitTaskFieldError? =
-        if (value.isNullOrBlank()) HabitTaskFieldError.Required else null
+    fun validateOption(value: String?, allowed: Set<String>): HabitTaskFieldError? {
+        if (value.isNullOrBlank()) return HabitTaskFieldError.Required
+        return if (value in allowed) null else HabitTaskFieldError.InvalidOption
+    }
 
     fun validatePeriodLength(value: String): HabitTaskFieldError? {
         val trimmed = value.trim()
         if (trimmed.isEmpty()) return HabitTaskFieldError.Required
         val parsed = trimmed.toIntOrNull() ?: return HabitTaskFieldError.InvalidNumber
-        return if (parsed < 1) HabitTaskFieldError.InvalidNumber else null
+        return when {
+            parsed < 1 -> HabitTaskFieldError.InvalidNumber
+            parsed > PERIOD_LENGTH_MAX -> HabitTaskFieldError.InvalidNumber
+            else -> null
+        }
     }
 
-    fun validateStartDate(value: String): HabitTaskFieldError? {
+    fun validateStartDate(
+        value: String,
+        options: HabitTaskValidationOptions = HabitTaskValidationOptions(),
+    ): HabitTaskFieldError? {
         val trimmed = value.trim()
-        return when {
-            trimmed.isEmpty() -> HabitTaskFieldError.Required
-            !DATE_REGEX.matches(trimmed) -> HabitTaskFieldError.InvalidDate
-            else -> runCatching {
-                java.time.LocalDate.parse(trimmed)
-                null
-            }.getOrElse { HabitTaskFieldError.InvalidDate }
-        }
+        if (trimmed.isEmpty()) return HabitTaskFieldError.Required
+        if (!DATE_REGEX.matches(trimmed)) return HabitTaskFieldError.InvalidDate
+
+        val parsed = runCatching { LocalDate.parse(trimmed) }
+            .getOrElse { return HabitTaskFieldError.InvalidDate }
+
+        val preservedDate = options.preservedStartDate
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { preserved -> runCatching { LocalDate.parse(preserved) }.getOrNull() }
+        if (preservedDate != null && parsed == preservedDate) return null
+        if (parsed.isBefore(options.today)) return HabitTaskFieldError.PastDate
+        return null
     }
 
     fun validateRepetitions(input: HabitTaskFormInput): HabitTaskFieldError? {
         if (input.completionCriteria != "REPETITIONS") return null
         if (input.repetitions.isBlank()) return HabitTaskFieldError.CriteriaRequired
         val parsed = input.repetitions.toIntOrNull() ?: return HabitTaskFieldError.InvalidNumber
-        return if (parsed < 1) HabitTaskFieldError.InvalidNumber else null
+        return when {
+            parsed < 1 -> HabitTaskFieldError.InvalidNumber
+            parsed > REPETITIONS_MAX -> HabitTaskFieldError.InvalidNumber
+            else -> null
+        }
     }
 
     fun validateMeasurementUnit(input: HabitTaskFormInput): HabitTaskFieldError? {
         if (input.completionCriteria != "REPETITIONS") return null
-        return if (input.measurementUnit.isNullOrBlank()) HabitTaskFieldError.CriteriaRequired else null
+        if (input.measurementUnit.isNullOrBlank()) return HabitTaskFieldError.CriteriaRequired
+        return validateOption(input.measurementUnit, MEASUREMENT_UNITS)
     }
 
     fun validateEvidence(input: HabitTaskFormInput): HabitTaskFieldError? {
         if (input.completionCriteria != "EVIDENCE") return null
-        return if (input.evidence.isNullOrBlank()) HabitTaskFieldError.EvidenceRequired else null
+        if (input.evidence.isNullOrBlank()) return HabitTaskFieldError.EvidenceRequired
+        return validateOption(input.evidence, EVIDENCE_TYPES)
+    }
+
+    fun validateTimerSeconds(input: HabitTaskFormInput): HabitTaskFieldError? {
+        if (input.completionCriteria != "TIMER") return null
+        if (input.timerSecondsDefined.isBlank()) return HabitTaskFieldError.CriteriaRequired
+        val parsed = input.timerSecondsDefined.toIntOrNull() ?: return HabitTaskFieldError.InvalidNumber
+        return when {
+            parsed < 1 -> HabitTaskFieldError.InvalidNumber
+            parsed > TIMER_SECONDS_MAX -> HabitTaskFieldError.InvalidNumber
+            else -> null
+        }
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskDisplay.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskDisplay.kt
@@ -59,6 +59,7 @@ object CreateHabitTaskOptions {
         repetitions: String,
         measurementUnit: String?,
         evidence: String?,
+        timerSecondsDefined: String = "",
     ): String = when (completionCriteria) {
         "REPETITIONS" -> {
             val count = repetitions.ifBlank { "—" }
@@ -66,6 +67,10 @@ object CreateHabitTaskOptions {
             "$count $unit"
         }
         "EVIDENCE" -> resolveLabel(evidenceTypes, evidence).ifBlank { "—" }
+        "TIMER" -> {
+            val seconds = timerSecondsDefined.ifBlank { "—" }
+            if (seconds == "—") "—" else "$seconds s"
+        }
         else -> "—"
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskScreen.kt
@@ -107,9 +107,10 @@ fun CreateHabitTaskScreen(
         containerColor = DarkBackground,
         bottomBar = {
             if (!state.isLoadingHabits && state.habitsLoadError == null) {
-                CreateTaskBottomBar(
+                HabitTaskFormBottomBar(
                     isSubmitting = state.isSubmitting,
                     enabled = !state.isSubmitting,
+                    submitLabelRes = R.string.create_task_submit,
                     onSubmit = viewModel::submit,
                 )
             }
@@ -140,10 +141,12 @@ fun CreateHabitTaskScreen(
                 }
             }
 
-            else -> CreateHabitTaskForm(
-                state = state,
+            else -> HabitTaskFormContent(
+                form = state.form,
                 contentPadding = innerPadding,
                 onBack = onBack,
+                showTemplates = true,
+                showHabitPicker = true,
                 onHabitSelected = viewModel::onHabitSelected,
                 onTitleChange = viewModel::onTitleChange,
                 onDescriptionChange = viewModel::onDescriptionChange,
@@ -165,9 +168,10 @@ fun CreateHabitTaskScreen(
 }
 
 @Composable
-private fun CreateTaskBottomBar(
+internal fun HabitTaskFormBottomBar(
     isSubmitting: Boolean,
     enabled: Boolean,
+    submitLabelRes: Int,
     onSubmit: () -> Unit,
 ) {
     Surface(
@@ -205,7 +209,7 @@ private fun CreateTaskBottomBar(
                     )
                 } else {
                     Text(
-                        text = stringResource(R.string.create_task_submit),
+                        text = stringResource(submitLabelRes),
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.SemiBold,
                     )
@@ -216,7 +220,7 @@ private fun CreateTaskBottomBar(
 }
 
 @Composable
-private fun CreateHabitTaskHeader(onBack: () -> Unit) {
+private fun CreateHabitTaskHeader(onBack: () -> Unit, isEditMode: Boolean = false) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.Top,
@@ -233,14 +237,18 @@ private fun CreateHabitTaskHeader(onBack: () -> Unit) {
         }
         Column(modifier = Modifier.padding(top = 8.dp, end = ScreenHorizontalPadding)) {
             Text(
-                text = stringResource(R.string.create_task_title),
+                text = stringResource(
+                    if (isEditMode) R.string.update_task_title else R.string.create_task_title,
+                ),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
                 color = DarkOnBackground,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = stringResource(R.string.create_task_subtitle),
+                text = stringResource(
+                    if (isEditMode) R.string.update_task_subtitle else R.string.create_task_subtitle,
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = DarkOnSurfaceVariant,
             )
@@ -250,10 +258,12 @@ private fun CreateHabitTaskHeader(onBack: () -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun CreateHabitTaskForm(
-    state: CreateHabitTaskUiState,
+internal fun HabitTaskFormContent(
+    form: HabitTaskFormState,
     contentPadding: PaddingValues,
     onBack: () -> Unit,
+    showTemplates: Boolean,
+    showHabitPicker: Boolean,
     onHabitSelected: (Int) -> Unit,
     onTitleChange: (String) -> Unit,
     onDescriptionChange: (String) -> Unit,
@@ -292,23 +302,33 @@ private fun CreateHabitTaskForm(
             .padding(bottom = contentPadding.calculateBottomPadding() + 88.dp),
         verticalArrangement = Arrangement.spacedBy(SectionSpacing),
     ) {
-        CreateHabitTaskHeader(onBack = onBack)
+        CreateHabitTaskHeader(onBack = onBack, isEditMode = !showTemplates)
 
-        QuickTemplatesRow(
-            selectedTemplateId = state.selectedTemplateId,
-            onApplyTemplate = onApplyTemplate,
-        )
+        if (showTemplates) {
+            QuickTemplatesRow(
+                selectedTemplateId = form.selectedTemplateId,
+                onApplyTemplate = onApplyTemplate,
+            )
+        }
 
         FormSection(title = stringResource(R.string.create_task_section_basic)) {
-            HabitDropdown(
-                habits = state.habits,
-                selectedHabit = state.selectedHabit,
-                error = if (state.showValidationErrors) state.fieldErrors.habitId else null,
-                onSelected = onHabitSelected,
-                fieldColors = fieldColors,
-            )
+            if (showHabitPicker) {
+                HabitDropdown(
+                    habits = form.habits,
+                    selectedHabit = form.selectedHabit,
+                    error = if (form.showValidationErrors) form.fieldErrors.habitId else null,
+                    onSelected = onHabitSelected,
+                    fieldColors = fieldColors,
+                )
+            } else {
+                ReadOnlyMetaField(
+                    label = stringResource(R.string.create_task_field_habit),
+                    value = form.selectedHabit?.title?.ifBlank { "—" } ?: "—",
+                    fieldColors = fieldColors,
+                )
+            }
 
-            val categoryLabel = state.selectedHabit?.categoryName?.takeIf { it.isNotBlank() }
+            val categoryLabel = form.selectedHabit?.categoryName?.takeIf { it.isNotBlank() }
                 ?: stringResource(R.string.create_task_category_unknown)
             ReadOnlyMetaField(
                 label = stringResource(R.string.create_task_field_category),
@@ -317,14 +337,14 @@ private fun CreateHabitTaskForm(
             )
 
             OutlinedTextField(
-                value = state.title,
+                value = form.title,
                 onValueChange = onTitleChange,
                 label = { Text(stringResource(R.string.create_task_field_title)) },
                 modifier = Modifier.fillMaxWidth(),
-                isError = state.showValidationErrors && state.fieldErrors.title != null,
+                isError = form.showValidationErrors && form.fieldErrors.title != null,
                 supportingText = {
-                    if (state.showValidationErrors && state.fieldErrors.title != null) {
-                        Text(state.fieldErrors.title!!.toMessage())
+                    if (form.showValidationErrors && form.fieldErrors.title != null) {
+                        Text(form.fieldErrors.title!!.toMessage())
                     }
                 },
                 colors = fieldColors,
@@ -332,7 +352,7 @@ private fun CreateHabitTaskForm(
             )
 
             OutlinedTextField(
-                value = state.description,
+                value = form.description,
                 onValueChange = onDescriptionChange,
                 label = { Text(stringResource(R.string.create_task_field_description)) },
                 modifier = Modifier.fillMaxWidth(),
@@ -346,29 +366,29 @@ private fun CreateHabitTaskForm(
             LabeledOptionDropdown(
                 label = stringResource(R.string.create_task_field_criteria_type),
                 options = CreateHabitTaskOptions.completionCriteria,
-                selected = state.completionCriteria,
-                error = if (state.showValidationErrors) state.fieldErrors.completionCriteria else null,
+                selected = form.completionCriteria,
+                error = if (form.showValidationErrors) form.fieldErrors.completionCriteria else null,
                 onSelected = onCompletionCriteriaChange,
                 fieldColors = fieldColors,
             )
 
-            if (state.completionCriteria == "REPETITIONS") {
+            if (form.completionCriteria == "REPETITIONS") {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(FieldSpacing),
                 ) {
                     OutlinedTextField(
-                        value = state.repetitions,
+                        value = form.repetitions,
                         onValueChange = onRepetitionsChange,
                         label = { Text(stringResource(R.string.create_task_field_repetitions)) },
                         modifier = Modifier.weight(1f),
-                        isError = state.showValidationErrors &&
-                            (state.fieldErrors.repetitions != null ||
-                                state.fieldErrors.measurementUnit != null),
+                        isError = form.showValidationErrors &&
+                            (form.fieldErrors.repetitions != null ||
+                                form.fieldErrors.measurementUnit != null),
                         supportingText = {
-                            val err = state.fieldErrors.repetitions
-                                ?: state.fieldErrors.measurementUnit
-                            if (state.showValidationErrors && err != null) Text(err.toMessage())
+                            val err = form.fieldErrors.repetitions
+                                ?: form.fieldErrors.measurementUnit
+                            if (form.showValidationErrors && err != null) Text(err.toMessage())
                         },
                         colors = fieldColors,
                         singleLine = true,
@@ -376,7 +396,7 @@ private fun CreateHabitTaskForm(
                     LabeledOptionDropdown(
                         label = stringResource(R.string.create_task_field_unit),
                         options = CreateHabitTaskOptions.measurementUnits,
-                        selected = state.measurementUnit,
+                        selected = form.measurementUnit,
                         error = null,
                         onSelected = onMeasurementUnitChange,
                         fieldColors = fieldColors,
@@ -385,17 +405,17 @@ private fun CreateHabitTaskForm(
                 }
 
                 PartialAllowedRow(
-                    checked = state.isPartialAllowed,
+                    checked = form.isPartialAllowed,
                     onCheckedChange = onPartialAllowedChange,
                 )
             }
 
-            if (state.completionCriteria == "EVIDENCE") {
+            if (form.completionCriteria == "EVIDENCE") {
                 LabeledOptionDropdown(
                     label = stringResource(R.string.create_task_field_evidence),
                     options = CreateHabitTaskOptions.evidenceTypes,
-                    selected = state.evidence,
-                    error = if (state.showValidationErrors) state.fieldErrors.evidence else null,
+                    selected = form.evidence,
+                    error = if (form.showValidationErrors) form.fieldErrors.evidence else null,
                     onSelected = onEvidenceChange,
                     fieldColors = fieldColors,
                 )
@@ -406,8 +426,8 @@ private fun CreateHabitTaskForm(
             LabeledOptionDropdown(
                 label = stringResource(R.string.create_task_field_difficulty),
                 options = CreateHabitTaskOptions.difficulties,
-                selected = state.difficulty,
-                error = if (state.showValidationErrors) state.fieldErrors.difficulty else null,
+                selected = form.difficulty,
+                error = if (form.showValidationErrors) form.fieldErrors.difficulty else null,
                 onSelected = onDifficultyChange,
                 fieldColors = fieldColors,
             )
@@ -415,8 +435,8 @@ private fun CreateHabitTaskForm(
             LabeledOptionDropdown(
                 label = stringResource(R.string.create_task_field_frequency),
                 options = CreateHabitTaskOptions.frequencies,
-                selected = state.frequency,
-                error = if (state.showValidationErrors) state.fieldErrors.frequency else null,
+                selected = form.frequency,
+                error = if (form.showValidationErrors) form.fieldErrors.frequency else null,
                 onSelected = onFrequencyChange,
                 fieldColors = fieldColors,
             )
@@ -426,14 +446,14 @@ private fun CreateHabitTaskForm(
                 horizontalArrangement = Arrangement.spacedBy(FieldSpacing),
             ) {
                 OutlinedTextField(
-                    value = state.periodLength,
+                    value = form.periodLength,
                     onValueChange = onPeriodLengthChange,
                     label = { Text(stringResource(R.string.create_task_field_period_length)) },
                     modifier = Modifier.weight(1f),
-                    isError = state.showValidationErrors && state.fieldErrors.periodLength != null,
+                    isError = form.showValidationErrors && form.fieldErrors.periodLength != null,
                     supportingText = {
-                        if (state.showValidationErrors && state.fieldErrors.periodLength != null) {
-                            Text(state.fieldErrors.periodLength!!.toMessage())
+                        if (form.showValidationErrors && form.fieldErrors.periodLength != null) {
+                            Text(form.fieldErrors.periodLength!!.toMessage())
                         }
                     },
                     colors = fieldColors,
@@ -442,8 +462,8 @@ private fun CreateHabitTaskForm(
                 LabeledOptionDropdown(
                     label = stringResource(R.string.create_task_field_period_unit),
                     options = CreateHabitTaskOptions.periodUnits,
-                    selected = state.periodUnit,
-                    error = if (state.showValidationErrors) state.fieldErrors.periodUnit else null,
+                    selected = form.periodUnit,
+                    error = if (form.showValidationErrors) form.fieldErrors.periodUnit else null,
                     onSelected = onPeriodUnitChange,
                     fieldColors = fieldColors,
                     modifier = Modifier.weight(1f),
@@ -451,22 +471,22 @@ private fun CreateHabitTaskForm(
             }
 
             OutlinedTextField(
-                value = state.startDate,
+                value = form.startDate,
                 onValueChange = onStartDateChange,
                 label = { Text(stringResource(R.string.create_task_field_start_date)) },
                 modifier = Modifier.fillMaxWidth(),
-                isError = state.showValidationErrors && state.fieldErrors.startDate != null,
-            supportingText = {
-                if (state.showValidationErrors && state.fieldErrors.startDate != null) {
-                    Text(state.fieldErrors.startDate!!.toMessage())
-                } else {
-                    Text(
-                        stringResource(R.string.create_task_start_date_hint),
-                        color = DarkOnSurfaceVariant,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-            },
+                isError = form.showValidationErrors && form.fieldErrors.startDate != null,
+                supportingText = {
+                    if (form.showValidationErrors && form.fieldErrors.startDate != null) {
+                        Text(form.fieldErrors.startDate!!.toMessage())
+                    } else {
+                        Text(
+                            stringResource(R.string.create_task_start_date_hint),
+                            color = DarkOnSurfaceVariant,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                },
                 colors = fieldColors,
                 singleLine = true,
             )
@@ -480,13 +500,13 @@ private fun CreateHabitTaskForm(
                 color = DarkOnBackground,
             )
             TaskPreviewCard(
-                state = state,
+                form = form,
                 modifier = Modifier.testTag(CreateHabitTaskTestTags.PREVIEW_CARD),
             )
         }
 
-        if (state.submitError != null) {
-            ErrorBanner(message = state.submitError ?: "", onDismiss = onDismissError)
+        if (form.submitError != null) {
+            ErrorBanner(message = form.submitError ?: "", onDismiss = onDismissError)
         }
 
         Spacer(Modifier.height(8.dp))
@@ -624,23 +644,23 @@ private fun PartialAllowedRow(
 }
 
 @Composable
-private fun TaskPreviewCard(state: CreateHabitTaskUiState, modifier: Modifier = Modifier) {
-    val habitTitle = state.selectedHabit?.title?.ifBlank { "—" } ?: "—"
-    val taskTitle = state.title.ifBlank { "—" }
-    val description = state.description.ifBlank {
+private fun TaskPreviewCard(form: HabitTaskFormState, modifier: Modifier = Modifier) {
+    val habitTitle = form.selectedHabit?.title?.ifBlank { "—" } ?: "—"
+    val taskTitle = form.title.ifBlank { "—" }
+    val description = form.description.ifBlank {
         stringResource(R.string.create_task_preview_no_description)
     }
     val goalLine = CreateHabitTaskOptions.previewGoalLine(
-        completionCriteria = state.completionCriteria,
-        repetitions = state.repetitions,
-        measurementUnit = state.measurementUnit,
-        evidence = state.evidence,
+        completionCriteria = form.completionCriteria,
+        repetitions = form.repetitions,
+        measurementUnit = form.measurementUnit,
+        evidence = form.evidence,
     )
     val frequencyLine = CreateHabitTaskOptions.resolveLabel(
         CreateHabitTaskOptions.frequencies,
-        state.frequency,
+        form.frequency,
     ).ifBlank { "—" }
-    val startLine = CreateHabitTaskOptions.formatStartDate(state.startDate)
+    val startLine = CreateHabitTaskOptions.formatStartDate(form.startDate)
 
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -694,7 +714,7 @@ private fun TaskPreviewCard(state: CreateHabitTaskUiState, modifier: Modifier = 
                 value = startLine,
             )
 
-            if (state.completionCriteria == "REPETITIONS" && state.isPartialAllowed) {
+            if (form.completionCriteria == "REPETITIONS" && form.isPartialAllowed) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskScreen.kt
@@ -363,14 +363,41 @@ internal fun HabitTaskFormContent(
         }
 
         FormSection(title = stringResource(R.string.create_task_section_goal)) {
-            LabeledOptionDropdown(
-                label = stringResource(R.string.create_task_field_criteria_type),
-                options = CreateHabitTaskOptions.completionCriteria,
-                selected = form.completionCriteria,
-                error = if (form.showValidationErrors) form.fieldErrors.completionCriteria else null,
-                onSelected = onCompletionCriteriaChange,
-                fieldColors = fieldColors,
-            )
+            if (!showTemplates && form.completionCriteria == "TIMER") {
+                ReadOnlyMetaField(
+                    label = stringResource(R.string.create_task_field_criteria_type),
+                    value = stringResource(R.string.create_task_option_criteria_timer),
+                    fieldColors = fieldColors,
+                )
+                ReadOnlyMetaField(
+                    label = stringResource(R.string.create_task_field_timer_seconds),
+                    value = form.timerSecondsDefined.ifBlank { "—" },
+                    fieldColors = fieldColors,
+                )
+                if (form.showValidationErrors && form.fieldErrors.timerSeconds != null) {
+                    Text(
+                        text = form.fieldErrors.timerSeconds!!.toMessage(),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                if (form.timerPauseAllowed) {
+                    Text(
+                        text = stringResource(R.string.create_task_timer_pause_allowed),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = DarkOnSurfaceVariant,
+                    )
+                }
+            } else {
+                LabeledOptionDropdown(
+                    label = stringResource(R.string.create_task_field_criteria_type),
+                    options = CreateHabitTaskOptions.completionCriteria,
+                    selected = form.completionCriteria,
+                    error = if (form.showValidationErrors) form.fieldErrors.completionCriteria else null,
+                    onSelected = onCompletionCriteriaChange,
+                    fieldColors = fieldColors,
+                )
+            }
 
             if (form.completionCriteria == "REPETITIONS") {
                 Row(
@@ -481,7 +508,13 @@ internal fun HabitTaskFormContent(
                         Text(form.fieldErrors.startDate!!.toMessage())
                     } else {
                         Text(
-                            stringResource(R.string.create_task_start_date_hint),
+                            stringResource(
+                                if (showTemplates) {
+                                    R.string.create_task_start_date_hint
+                                } else {
+                                    R.string.update_task_start_date_hint
+                                },
+                            ),
                             color = DarkOnSurfaceVariant,
                             style = MaterialTheme.typography.bodySmall,
                         )
@@ -655,6 +688,7 @@ private fun TaskPreviewCard(form: HabitTaskFormState, modifier: Modifier = Modif
         repetitions = form.repetitions,
         measurementUnit = form.measurementUnit,
         evidence = form.evidence,
+        timerSecondsDefined = form.timerSecondsDefined,
     )
     val frequencyLine = CreateHabitTaskOptions.resolveLabel(
         CreateHabitTaskOptions.frequencies,

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskUiMessages.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskUiMessages.kt
@@ -12,6 +12,8 @@ fun HabitTaskFieldError.toMessage(): String = when (this) {
     is HabitTaskFieldError.TooLong -> stringResource(R.string.field_max_length, max)
     HabitTaskFieldError.InvalidNumber -> stringResource(R.string.create_task_error_invalid_number)
     HabitTaskFieldError.InvalidDate -> stringResource(R.string.create_task_error_invalid_date)
+    HabitTaskFieldError.PastDate -> stringResource(R.string.create_task_error_past_date)
+    HabitTaskFieldError.InvalidOption -> stringResource(R.string.create_task_error_invalid_option)
     HabitTaskFieldError.CriteriaRequired -> stringResource(R.string.create_task_error_criteria_required)
     HabitTaskFieldError.EvidenceRequired -> stringResource(R.string.create_task_error_evidence_required)
 }

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/CreateHabitTaskUiState.kt
@@ -2,32 +2,34 @@ package com.example.leveluplife.ui.createtask
 
 import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.network.dto.HabitTaskDto
-import com.example.leveluplife.domain.validation.HabitTaskFormErrors
+import java.time.LocalDate
 
 data class CreateHabitTaskUiState(
-    val habits: List<HabitDto> = emptyList(),
+    val form: HabitTaskFormState = HabitTaskFormState(
+        startDate = LocalDate.now().toString(),
+    ),
     val isLoadingHabits: Boolean = true,
     val habitsLoadError: String? = null,
-    val selectedHabitId: Int? = null,
-    val title: String = "",
-    val description: String = "",
-    val difficulty: String? = "MEDIUM",
-    val frequency: String? = "WEEKLY",
-    val periodLength: String = "1",
-    val periodUnit: String? = "WEEKS",
-    val startDate: String = "",
-    val completionCriteria: String? = "REPETITIONS",
-    val repetitions: String = "3",
-    val measurementUnit: String? = "SERIES",
-    val evidence: String? = null,
-    val isPartialAllowed: Boolean = true,
-    val selectedTemplateId: String? = null,
-    val fieldErrors: HabitTaskFormErrors = HabitTaskFormErrors(),
-    val showValidationErrors: Boolean = false,
     val isSubmitting: Boolean = false,
-    val submitError: String? = null,
     val createdTask: HabitTaskDto? = null,
 ) {
-    val selectedHabit: HabitDto?
-        get() = habits.firstOrNull { it.id == selectedHabitId }
+    val habits: List<HabitDto> get() = form.habits
+    val selectedHabitId: Int? get() = form.selectedHabitId
+    val selectedHabit: HabitDto? get() = form.selectedHabit
+    val title get() = form.title
+    val description get() = form.description
+    val difficulty get() = form.difficulty
+    val frequency get() = form.frequency
+    val periodLength get() = form.periodLength
+    val periodUnit get() = form.periodUnit
+    val startDate get() = form.startDate
+    val completionCriteria get() = form.completionCriteria
+    val repetitions get() = form.repetitions
+    val measurementUnit get() = form.measurementUnit
+    val evidence get() = form.evidence
+    val isPartialAllowed get() = form.isPartialAllowed
+    val selectedTemplateId get() = form.selectedTemplateId
+    val fieldErrors get() = form.fieldErrors
+    val showValidationErrors get() = form.showValidationErrors
+    val submitError get() = form.submitError
 }

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/HabitTaskFormState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/HabitTaskFormState.kt
@@ -1,0 +1,228 @@
+package com.example.leveluplife.ui.createtask
+
+import com.example.leveluplife.data.network.dto.CreateHabitTaskRequest
+import com.example.leveluplife.data.network.dto.CreateRepetitionCriteriaRequest
+import com.example.leveluplife.data.network.dto.HabitDto
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.domain.validation.HabitTaskFormErrors
+import com.example.leveluplife.domain.validation.HabitTaskFormInput
+import com.example.leveluplife.domain.validation.HabitTaskValidators
+import com.example.leveluplife.domain.validation.TaskInputSanitizer
+
+data class HabitTaskFormState(
+    val habits: List<HabitDto> = emptyList(),
+    val selectedHabitId: Int? = null,
+    val title: String = "",
+    val description: String = "",
+    val difficulty: String? = "MEDIUM",
+    val frequency: String? = "WEEKLY",
+    val periodLength: String = "1",
+    val periodUnit: String? = "WEEKS",
+    val startDate: String = "",
+    val completionCriteria: String? = "REPETITIONS",
+    val repetitions: String = "3",
+    val measurementUnit: String? = "SERIES",
+    val evidence: String? = null,
+    val isPartialAllowed: Boolean = true,
+    val selectedTemplateId: String? = null,
+    val fieldErrors: HabitTaskFormErrors = HabitTaskFormErrors(),
+    val showValidationErrors: Boolean = false,
+    val submitError: String? = null,
+) {
+    val selectedHabit: HabitDto?
+        get() = habits.firstOrNull { it.id == selectedHabitId }
+
+    fun sanitizedForValidation(): HabitTaskFormState = copy(
+        title = title.trim(),
+        description = description.trim(),
+        periodLength = periodLength.trim(),
+        startDate = startDate.trim(),
+        repetitions = repetitions.trim(),
+    )
+
+    fun toFormInput(): HabitTaskFormInput = HabitTaskFormInput(
+        habitId = selectedHabitId,
+        title = title,
+        description = description,
+        difficulty = difficulty,
+        frequency = frequency,
+        periodLength = periodLength,
+        periodUnit = periodUnit,
+        startDate = startDate,
+        completionCriteria = completionCriteria,
+        repetitions = repetitions,
+        measurementUnit = measurementUnit,
+        evidence = evidence,
+        isPartialAllowed = isPartialAllowed,
+    )
+
+    fun toRequest(): CreateHabitTaskRequest? {
+        val habitId = selectedHabitId ?: return null
+        val criteria = completionCriteria ?: return null
+        val period = periodLength.toIntOrNull() ?: return null
+        val periodUnitValue = periodUnit ?: return null
+
+        val repetitionCriteria = when (criteria) {
+            "REPETITIONS" -> {
+                val reps = repetitions.toIntOrNull() ?: return null
+                val unit = measurementUnit ?: return null
+                CreateRepetitionCriteriaRequest(
+                    repetitions = reps,
+                    measurementUnit = unit,
+                    isPartialAllowed = isPartialAllowed,
+                    isActive = true,
+                )
+            }
+            else -> null
+        }
+
+        if (criteria == "EVIDENCE" && evidence.isNullOrBlank()) return null
+
+        return CreateHabitTaskRequest(
+            habitId = habitId,
+            title = title.trim(),
+            description = description.trim().ifBlank { null },
+            difficulty = difficulty!!,
+            frequency = frequency!!,
+            periodLength = period,
+            periodUnit = periodUnitValue,
+            startDate = startDate.trim(),
+            completionCriteria = criteria,
+            evidence = if (criteria == "EVIDENCE") evidence else null,
+            repetitionCriteria = repetitionCriteria,
+            isActive = true,
+        )
+    }
+
+    companion object {
+        fun fromTask(task: HabitTaskDto, habits: List<HabitDto>): HabitTaskFormState = HabitTaskFormState(
+            habits = habits,
+            selectedHabitId = task.habitId,
+            title = task.title,
+            description = task.description.orEmpty(),
+            difficulty = task.difficulty,
+            frequency = task.frequency,
+            periodLength = task.periodLength.toString(),
+            periodUnit = task.periodUnit,
+            startDate = task.startDate,
+            completionCriteria = task.completionCriteria,
+            repetitions = task.repetitionCriteria?.repetitions?.toString().orEmpty(),
+            measurementUnit = task.repetitionCriteria?.measurementUnit,
+            evidence = task.evidence,
+            isPartialAllowed = task.repetitionCriteria?.isPartialAllowed ?: false,
+        )
+
+        fun applyTemplate(current: HabitTaskFormState, template: TaskFormTemplate): HabitTaskFormState =
+            current.copy(
+                title = template.title,
+                description = template.description,
+                difficulty = template.difficulty,
+                frequency = template.frequency,
+                periodLength = template.periodLength,
+                periodUnit = template.periodUnit,
+                completionCriteria = template.completionCriteria,
+                repetitions = template.repetitions,
+                measurementUnit = template.measurementUnit,
+                evidence = template.evidence,
+                isPartialAllowed = template.isPartialAllowed,
+                selectedTemplateId = template.id,
+                fieldErrors = HabitTaskFormErrors(),
+                showValidationErrors = false,
+                submitError = null,
+            )
+    }
+}
+
+object HabitTaskFormHandlers {
+    fun onTitleChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            title = TaskInputSanitizer.trimToMax(value, HabitTaskValidators.TITLE_MAX),
+            fieldErrors = state.fieldErrors.copy(title = null),
+            submitError = null,
+        )
+
+    fun onDescriptionChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            description = TaskInputSanitizer.trimToMax(value, 500),
+            submitError = null,
+        )
+
+    fun onDifficultyChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            difficulty = value,
+            fieldErrors = state.fieldErrors.copy(difficulty = null),
+            submitError = null,
+        )
+
+    fun onFrequencyChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            frequency = value,
+            fieldErrors = state.fieldErrors.copy(frequency = null),
+            submitError = null,
+        )
+
+    fun onPeriodLengthChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            periodLength = TaskInputSanitizer.digitsOnly(value),
+            fieldErrors = state.fieldErrors.copy(periodLength = null),
+            submitError = null,
+        )
+
+    fun onPeriodUnitChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            periodUnit = value,
+            fieldErrors = state.fieldErrors.copy(periodUnit = null),
+            submitError = null,
+        )
+
+    fun onStartDateChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            startDate = TaskInputSanitizer.isoDateInput(value),
+            fieldErrors = state.fieldErrors.copy(startDate = null),
+            submitError = null,
+        )
+
+    fun onCompletionCriteriaChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            completionCriteria = value,
+            repetitions = if (value == "REPETITIONS" && state.repetitions.isBlank()) "3" else state.repetitions,
+            measurementUnit = if (value == "REPETITIONS") state.measurementUnit ?: "SERIES" else null,
+            evidence = if (value == "EVIDENCE") state.evidence ?: "PHOTO" else null,
+            fieldErrors = state.fieldErrors.copy(
+                completionCriteria = null,
+                repetitions = null,
+                measurementUnit = null,
+                evidence = null,
+            ),
+            submitError = null,
+        )
+
+    fun onRepetitionsChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            repetitions = TaskInputSanitizer.digitsOnly(value, maxLength = 5),
+            fieldErrors = state.fieldErrors.copy(repetitions = null),
+            submitError = null,
+        )
+
+    fun onMeasurementUnitChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            measurementUnit = value,
+            fieldErrors = state.fieldErrors.copy(measurementUnit = null),
+            submitError = null,
+        )
+
+    fun onEvidenceChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
+        state.copy(
+            evidence = value,
+            fieldErrors = state.fieldErrors.copy(evidence = null),
+            submitError = null,
+        )
+
+    fun onHabitSelected(state: HabitTaskFormState, habitId: Int): HabitTaskFormState =
+        state.copy(
+            selectedHabitId = habitId,
+            fieldErrors = state.fieldErrors.copy(habitId = null),
+            showValidationErrors = false,
+            submitError = null,
+        )
+}

--- a/app/src/main/java/com/example/leveluplife/ui/createtask/HabitTaskFormState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/createtask/HabitTaskFormState.kt
@@ -2,6 +2,7 @@ package com.example.leveluplife.ui.createtask
 
 import com.example.leveluplife.data.network.dto.CreateHabitTaskRequest
 import com.example.leveluplife.data.network.dto.CreateRepetitionCriteriaRequest
+import com.example.leveluplife.data.network.dto.CreateTimerCriteriaRequest
 import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.network.dto.HabitTaskDto
 import com.example.leveluplife.domain.validation.HabitTaskFormErrors
@@ -24,6 +25,9 @@ data class HabitTaskFormState(
     val measurementUnit: String? = "SERIES",
     val evidence: String? = null,
     val isPartialAllowed: Boolean = true,
+    val timerSecondsDefined: String = "",
+    val timerSecondsLong: String = "",
+    val timerPauseAllowed: Boolean = false,
     val selectedTemplateId: String? = null,
     val fieldErrors: HabitTaskFormErrors = HabitTaskFormErrors(),
     val showValidationErrors: Boolean = false,
@@ -38,6 +42,8 @@ data class HabitTaskFormState(
         periodLength = periodLength.trim(),
         startDate = startDate.trim(),
         repetitions = repetitions.trim(),
+        timerSecondsDefined = timerSecondsDefined.trim(),
+        timerSecondsLong = timerSecondsLong.trim(),
     )
 
     fun toFormInput(): HabitTaskFormInput = HabitTaskFormInput(
@@ -54,6 +60,7 @@ data class HabitTaskFormState(
         measurementUnit = measurementUnit,
         evidence = evidence,
         isPartialAllowed = isPartialAllowed,
+        timerSecondsDefined = timerSecondsDefined,
     )
 
     fun toRequest(): CreateHabitTaskRequest? {
@@ -76,6 +83,19 @@ data class HabitTaskFormState(
             else -> null
         }
 
+        val timerCriteria = when (criteria) {
+            "TIMER" -> {
+                val seconds = timerSecondsDefined.toIntOrNull() ?: return null
+                CreateTimerCriteriaRequest(
+                    numSecondsDefined = seconds,
+                    numSecondsLong = timerSecondsLong.toIntOrNull(),
+                    typePauseIsAllowed = timerPauseAllowed,
+                    statusTimerCriteriaIsActive = true,
+                )
+            }
+            else -> null
+        }
+
         if (criteria == "EVIDENCE" && evidence.isNullOrBlank()) return null
 
         return CreateHabitTaskRequest(
@@ -90,6 +110,7 @@ data class HabitTaskFormState(
             completionCriteria = criteria,
             evidence = if (criteria == "EVIDENCE") evidence else null,
             repetitionCriteria = repetitionCriteria,
+            timerCriteria = timerCriteria,
             isActive = true,
         )
     }
@@ -110,6 +131,9 @@ data class HabitTaskFormState(
             measurementUnit = task.repetitionCriteria?.measurementUnit,
             evidence = task.evidence,
             isPartialAllowed = task.repetitionCriteria?.isPartialAllowed ?: false,
+            timerSecondsDefined = task.timerCriteria?.numSecondsDefined?.toString().orEmpty(),
+            timerSecondsLong = task.timerCriteria?.numSecondsLong?.toString().orEmpty(),
+            timerPauseAllowed = task.timerCriteria?.typePauseIsAllowed ?: false,
         )
 
         fun applyTemplate(current: HabitTaskFormState, template: TaskFormTemplate): HabitTaskFormState =
@@ -143,7 +167,7 @@ object HabitTaskFormHandlers {
 
     fun onDescriptionChange(state: HabitTaskFormState, value: String): HabitTaskFormState =
         state.copy(
-            description = TaskInputSanitizer.trimToMax(value, 500),
+            description = TaskInputSanitizer.trimToMax(value, HabitTaskValidators.DESCRIPTION_MAX),
             submitError = null,
         )
 

--- a/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.example.leveluplife.ui.habitdetail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -56,6 +57,7 @@ private val OrangeWarn = Color(0xFFF59E0B)
 fun HabitDetailScreen(
     viewModel: HabitDetailViewModel,
     onBack: () -> Unit,
+    onTaskClick: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -122,14 +124,20 @@ fun HabitDetailScreen(
                     }
                 }
 
-                state.habit != null -> HabitDetailContent(habit = requireNotNull(state.habit))
+                state.habit != null -> HabitDetailContent(
+                    habit = requireNotNull(state.habit),
+                    onTaskClick = onTaskClick,
+                )
             }
         }
     }
 }
 
 @Composable
-private fun HabitDetailContent(habit: HabitDto) {
+private fun HabitDetailContent(
+    habit: HabitDto,
+    onTaskClick: (Int) -> Unit,
+) {
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -150,7 +158,11 @@ private fun HabitDetailContent(habit: HabitDto) {
             }
 
             itemsIndexed(habit.tasks) { index, task ->
-                TaskCriteriaCard(taskNumber = index + 1, task = task)
+                TaskCriteriaCard(
+                    taskNumber = index + 1,
+                    task = task,
+                    onClick = { onTaskClick(task.id) },
+                )
             }
         }
 
@@ -240,6 +252,7 @@ private fun HabitInfoCard(habit: HabitDto) {
 private fun TaskCriteriaCard(
     taskNumber: Int,
     task: HabitTaskDto,
+    onClick: () -> Unit = {},
 ) {
     val criteria = task.repetitionCriteria
     val label = task.title.takeIf { it.isNotBlank() } ?: "Objetivo $taskNumber"
@@ -247,7 +260,9 @@ private fun TaskCriteriaCard(
     Card(
         shape = RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
     ) {
         Row(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habitdetail/HabitDetailScreen.kt
@@ -40,9 +40,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import com.example.leveluplife.R
 import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.network.dto.HabitTaskDto
 import com.example.leveluplife.data.network.dto.RepetitionCriteriaDto
+import com.example.leveluplife.ui.habittaskdetail.HabitTaskLabels
 import com.example.leveluplife.ui.theme.DarkBackground
 import com.example.leveluplife.ui.theme.DarkOnBackground
 import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
@@ -57,7 +60,7 @@ private val OrangeWarn = Color(0xFFF59E0B)
 fun HabitDetailScreen(
     viewModel: HabitDetailViewModel,
     onBack: () -> Unit,
-    onTaskClick: (Int) -> Unit = {},
+    onTaskClick: (HabitTaskDto) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -119,7 +122,7 @@ fun HabitDetailScreen(
                         )
                         Spacer(Modifier.height(12.dp))
                         TextButton(onClick = { viewModel.loadHabit() }) {
-                            Text("Reintentar", color = PurplePrimary)
+                            Text(stringResource(R.string.create_task_retry), color = PurplePrimary)
                         }
                     }
                 }
@@ -136,7 +139,7 @@ fun HabitDetailScreen(
 @Composable
 private fun HabitDetailContent(
     habit: HabitDto,
-    onTaskClick: (Int) -> Unit,
+    onTaskClick: (HabitTaskDto) -> Unit,
 ) {
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
@@ -148,7 +151,7 @@ private fun HabitDetailContent(
             item {
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "TAREAS Y CRITERIOS",
+                    text = stringResource(R.string.habit_detail_tasks_section),
                     fontSize = 11.sp,
                     letterSpacing = 2.sp,
                     fontWeight = FontWeight.SemiBold,
@@ -161,7 +164,7 @@ private fun HabitDetailContent(
                 TaskCriteriaCard(
                     taskNumber = index + 1,
                     task = task,
-                    onClick = { onTaskClick(task.id) },
+                    onClick = { onTaskClick(task) },
                 )
             }
         }
@@ -210,7 +213,11 @@ private fun HabitInfoCard(habit: HabitDto) {
             Spacer(Modifier.height(12.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
                 val taskCount = habit.tasks.size
-                val withCriteria = habit.tasks.count { it.repetitionCriteria != null }
+                val withCriteria = habit.tasks.count { task ->
+                    task.repetitionCriteria != null ||
+                        task.timerCriteria != null ||
+                        !task.evidence.isNullOrBlank()
+                }
 
                 Box(
                     modifier = Modifier
@@ -236,7 +243,7 @@ private fun HabitInfoCard(habit: HabitDto) {
                             .padding(horizontal = 10.dp, vertical = 4.dp),
                     ) {
                         Text(
-                            text = "$withCriteria con criterios",
+                            text = stringResource(R.string.habit_detail_with_criteria, withCriteria),
                             fontSize = 12.sp,
                             color = GreenSuccess,
                             fontWeight = FontWeight.Medium,
@@ -254,8 +261,11 @@ private fun TaskCriteriaCard(
     task: HabitTaskDto,
     onClick: () -> Unit = {},
 ) {
-    val criteria = task.repetitionCriteria
-    val label = task.title.takeIf { it.isNotBlank() } ?: "Objetivo $taskNumber"
+    val label = task.title.takeIf { it.isNotBlank() }
+        ?: stringResource(R.string.habit_detail_task_default_title, taskNumber)
+    val criteriaType = HabitTaskLabels.completionCriteria(task.completionCriteria)
+    val goalSummary = HabitTaskLabels.criteriaGoalSummary(task)
+    val frequencyLine = HabitTaskLabels.frequency(task.frequency)
 
     Card(
         shape = RoundedCornerShape(14.dp),
@@ -292,23 +302,28 @@ private fun TaskCriteriaCard(
                     color = DarkOnBackground,
                 )
 
-                if (criteria != null) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringResource(
+                        R.string.habit_detail_task_subtitle,
+                        criteriaType,
+                        goalSummary,
+                        frequencyLine,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = DarkOnSurfaceVariant,
+                )
+
+                task.repetitionCriteria?.let { criteria ->
                     Spacer(Modifier.height(6.dp))
                     CriteriaRow(criteria)
-                } else {
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = "Sin criterios de repetición",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = DarkOnSurfaceVariant,
-                    )
                 }
             }
 
-            if (criteria?.isActive == true) {
+            if (task.isCompleted) {
                 Icon(
                     Icons.Filled.CheckCircle,
-                    contentDescription = "Activo",
+                    contentDescription = stringResource(R.string.task_detail_status_completed),
                     tint = GreenSuccess,
                     modifier = Modifier.size(20.dp),
                 )
@@ -330,14 +345,14 @@ private fun CriteriaRow(criteria: RepetitionCriteriaDto) {
         )
         if (criteria.isPartialAllowed) {
             CriteriaChip(
-                label = "Admite parcial",
+                label = stringResource(R.string.create_task_partial_allowed),
                 background = OrangeWarn.copy(alpha = 0.15f),
                 textColor = OrangeWarn,
             )
         }
         if (!criteria.isActive) {
             CriteriaChip(
-                label = "Inactivo",
+                label = stringResource(R.string.task_detail_criteria_inactive),
                 background = DarkOnSurfaceVariant.copy(alpha = 0.12f),
                 textColor = DarkOnSurfaceVariant,
             )

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailScreen.kt
@@ -1,10 +1,10 @@
 package com.example.leveluplife.ui.habittaskdetail
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,24 +12,26 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.annotation.StringRes
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.leveluplife.R
 import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.ui.createtask.CreateHabitTaskOptions
 import com.example.leveluplife.ui.theme.DarkBackground
 import com.example.leveluplife.ui.theme.DarkOnBackground
 import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
@@ -52,13 +55,14 @@ private val OrangeWarn = Color(0xFFF59E0B)
 
 @Composable
 fun HabitTaskDetailScreen(
-    task: HabitTaskDto,
+    viewModel: HabitTaskDetailViewModel,
     @StringRes successMessageRes: Int? = null,
     onBack: () -> Unit,
     onDone: () -> Unit,
-    onEdit: (() -> Unit)? = null,
+    onEdit: ((HabitTaskDto) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
+    val state by viewModel.state.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val confirmationMessage = successMessageRes?.let { stringResource(it) }
 
@@ -78,141 +82,270 @@ fun HabitTaskDetailScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                IconButton(onClick = onBack) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(R.string.create_task_back),
-                        tint = DarkOnBackground,
+            DetailHeader(
+                onBack = onBack,
+                onEdit = state.task?.takeIf { it.isActive }?.let { task ->
+                    onEdit?.let { edit -> { edit(task) } }
+                },
+            )
+
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(color = PurplePrimary, modifier = Modifier.size(44.dp))
+                }
+
+                state.loadError != null -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.loadError ?: "", color = DarkOnSurfaceVariant)
+                        Spacer(Modifier.height(12.dp))
+                        TextButton(onClick = viewModel::loadTask) {
+                            Text(stringResource(R.string.create_task_retry), color = PurplePrimary)
+                        }
+                    }
+                }
+
+                state.task != null -> HabitTaskDetailContent(
+                    task = state.task!!,
+                    habitTitle = state.habitTitle,
+                    onDone = onDone,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailHeader(
+    onBack: () -> Unit,
+    onEdit: (() -> Unit)?,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(R.string.create_task_back),
+                tint = DarkOnBackground,
+            )
+        }
+        Text(
+            text = stringResource(R.string.task_detail_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = DarkOnBackground,
+            modifier = Modifier.weight(1f),
+        )
+        if (onEdit != null) {
+            TextButton(onClick = onEdit) {
+                Text(
+                    text = stringResource(R.string.update_task_edit),
+                    color = PurplePrimary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HabitTaskDetailContent(
+    task: HabitTaskDto,
+    habitTitle: String?,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (!habitTitle.isNullOrBlank()) {
+                    Text(
+                        text = habitTitle,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = PurplePrimary,
                     )
                 }
                 Text(
-                    text = stringResource(R.string.task_detail_title),
-                    style = MaterialTheme.typography.titleMedium,
+                    text = task.title.ifBlank { stringResource(R.string.task_detail_untitled) },
+                    style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = DarkOnBackground,
-                    modifier = Modifier.weight(1f),
                 )
-                if (task.isActive) {
-                    Icon(
-                        Icons.Filled.CheckCircle,
-                        contentDescription = null,
-                        tint = GreenSuccess,
-                        modifier = Modifier.size(22.dp),
-                    )
-                }
-                if (onEdit != null) {
-                    TextButton(onClick = onEdit) {
-                        Text(
-                            text = stringResource(R.string.update_task_edit),
-                            color = PurplePrimary,
-                        )
-                    }
-                }
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 20.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Card(
-                    shape = RoundedCornerShape(16.dp),
-                    colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Column(modifier = Modifier.padding(18.dp)) {
-                        Text(
-                            text = task.title,
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.Bold,
-                            color = DarkOnBackground,
-                        )
-                        if (!task.description.isNullOrBlank()) {
-                            Spacer(Modifier.height(8.dp))
-                            Text(
-                                text = task.description,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = DarkOnBackground,
-                            )
-                        }
-                        Spacer(Modifier.height(12.dp))
-                        Text(
-                            text = stringResource(
-                                R.string.task_detail_meta,
-                                task.difficulty,
-                                task.frequency,
-                                task.startDate,
-                            ),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = DarkOnSurfaceVariant,
-                        )
-                    }
-                }
-
                 Text(
-                    text = stringResource(R.string.task_detail_criteria_section),
-                    fontSize = 11.sp,
-                    letterSpacing = 2.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    text = task.description?.takeIf { it.isNotBlank() }
+                        ?: stringResource(R.string.create_task_preview_no_description),
+                    style = MaterialTheme.typography.bodyMedium,
                     color = DarkOnSurfaceVariant,
                 )
-
-                Card(
-                    shape = RoundedCornerShape(14.dp),
-                    colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(
-                            text = task.completionCriteria,
-                            fontWeight = FontWeight.SemiBold,
-                            color = DarkOnBackground,
+                Spacer(Modifier.height(4.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (task.isCompleted) {
+                        StatusChip(
+                            label = stringResource(R.string.task_detail_status_completed),
+                            background = GreenSuccess.copy(alpha = 0.15f),
+                            textColor = GreenSuccess,
                         )
-                        task.repetitionCriteria?.let { criteria ->
-                            Spacer(Modifier.height(8.dp))
-                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                CriteriaChip(
-                                    label = criteria.toReadableSummary(),
-                                    background = PurplePrimaryContainer,
-                                    textColor = PurplePrimary,
-                                )
-                                if (criteria.isPartialAllowed) {
-                                    CriteriaChip(
-                                        label = stringResource(R.string.create_task_partial_allowed),
-                                        background = OrangeWarn.copy(alpha = 0.15f),
-                                        textColor = OrangeWarn,
-                                    )
-                                }
-                            }
-                        }
-                        if (task.evidence != null) {
-                            Spacer(Modifier.height(8.dp))
-                            CriteriaChip(
-                                label = task.evidence,
-                                background = PurplePrimaryContainer,
-                                textColor = PurplePrimary,
-                            )
-                        }
                     }
-                }
-
-                Spacer(Modifier.weight(1f))
-
-                androidx.compose.material3.TextButton(
-                    onClick = onDone,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(stringResource(R.string.task_detail_back_home), color = PurplePrimary)
+                    StatusChip(
+                        label = if (task.isActive) {
+                            stringResource(R.string.task_detail_status_active)
+                        } else {
+                            stringResource(R.string.task_detail_status_inactive)
+                        },
+                        background = if (task.isActive) {
+                            PurplePrimaryContainer
+                        } else {
+                            DarkOnSurfaceVariant.copy(alpha = 0.12f)
+                        },
+                        textColor = if (task.isActive) PurplePrimary else DarkOnSurfaceVariant,
+                    )
                 }
             }
         }
+
+        SectionTitle(stringResource(R.string.task_detail_planning_section))
+
+        Card(
+            shape = RoundedCornerShape(14.dp),
+            colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                DetailRow(
+                    label = stringResource(R.string.create_task_field_difficulty),
+                    value = HabitTaskLabels.difficulty(task.difficulty),
+                )
+                DetailRow(
+                    label = stringResource(R.string.create_task_field_frequency),
+                    value = HabitTaskLabels.frequency(task.frequency),
+                )
+                DetailRow(
+                    label = stringResource(R.string.task_detail_plan_duration),
+                    value = HabitTaskLabels.periodSummary(task.periodLength, task.periodUnit),
+                )
+                DetailRow(
+                    label = stringResource(R.string.create_task_field_start_date),
+                    value = CreateHabitTaskOptions.formatStartDate(task.startDate),
+                )
+                if (task.xpValue > 0) {
+                    DetailRow(
+                        label = stringResource(R.string.task_detail_xp),
+                        value = stringResource(R.string.task_detail_xp_value, task.xpValue),
+                    )
+                }
+                if (!task.weekDays.isNullOrBlank()) {
+                    DetailRow(
+                        label = stringResource(R.string.task_detail_week_days),
+                        value = HabitTaskLabels.weekDays(task.weekDays),
+                    )
+                }
+            }
+        }
+
+        SectionTitle(stringResource(R.string.task_detail_criteria_section))
+
+        Card(
+            shape = RoundedCornerShape(14.dp),
+            colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                DetailRow(
+                    label = stringResource(R.string.create_task_field_criteria_type),
+                    value = HabitTaskLabels.completionCriteria(task.completionCriteria),
+                )
+                DetailRow(
+                    label = stringResource(R.string.task_detail_criteria_goal),
+                    value = HabitTaskLabels.criteriaGoalSummary(task),
+                )
+                task.repetitionCriteria?.let { criteria ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (criteria.isPartialAllowed) {
+                            CriteriaChip(
+                                label = stringResource(R.string.create_task_partial_allowed),
+                                background = OrangeWarn.copy(alpha = 0.15f),
+                                textColor = OrangeWarn,
+                            )
+                        }
+                        if (!criteria.isActive) {
+                            CriteriaChip(
+                                label = stringResource(R.string.task_detail_criteria_inactive),
+                                background = DarkOnSurfaceVariant.copy(alpha = 0.12f),
+                                textColor = DarkOnSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        TextButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.task_detail_back_home), color = PurplePrimary)
+        }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text = text,
+        fontSize = 11.sp,
+        letterSpacing = 2.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = DarkOnSurfaceVariant,
+    )
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = DarkOnSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = DarkOnBackground,
+        )
+    }
+}
+
+@Composable
+private fun StatusChip(label: String, background: Color, textColor: Color) {
+    Box(
+        modifier = Modifier
+            .background(background, RoundedCornerShape(8.dp))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(label, fontSize = 12.sp, fontWeight = FontWeight.Medium, color = textColor)
     }
 }
 

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.annotation.StringRes
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -51,16 +53,17 @@ private val OrangeWarn = Color(0xFFF59E0B)
 @Composable
 fun HabitTaskDetailScreen(
     task: HabitTaskDto,
-    showConfirmation: Boolean,
+    @StringRes successMessageRes: Int? = null,
     onBack: () -> Unit,
     onDone: () -> Unit,
+    onEdit: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-    val confirmationMessage = stringResource(R.string.create_task_success_message)
+    val confirmationMessage = successMessageRes?.let { stringResource(it) }
 
-    LaunchedEffect(showConfirmation) {
-        if (showConfirmation) {
+    LaunchedEffect(successMessageRes) {
+        if (confirmationMessage != null) {
             snackbarHostState.showSnackbar(confirmationMessage)
         }
     }
@@ -102,6 +105,14 @@ fun HabitTaskDetailScreen(
                         tint = GreenSuccess,
                         modifier = Modifier.size(22.dp),
                     )
+                }
+                if (onEdit != null) {
+                    TextButton(onClick = onEdit) {
+                        Text(
+                            text = stringResource(R.string.update_task_edit),
+                            color = PurplePrimary,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailUiState.kt
@@ -1,0 +1,10 @@
+package com.example.leveluplife.ui.habittaskdetail
+
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+
+data class HabitTaskDetailUiState(
+    val task: HabitTaskDto? = null,
+    val habitTitle: String? = null,
+    val isLoading: Boolean = true,
+    val loadError: String? = null,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModel.kt
@@ -1,0 +1,88 @@
+package com.example.leveluplife.ui.habittaskdetail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.leveluplife.data.habits.HabitRepository
+import com.example.leveluplife.data.habits.HabitTaskRepository
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+class HabitTaskDetailViewModel(
+    private val taskId: Int,
+    private val habitTaskRepository: HabitTaskRepository,
+    private val habitRepository: HabitRepository,
+    initialTask: HabitTaskDto?,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(
+        HabitTaskDetailUiState(
+            task = initialTask?.takeIf { isPreviewUsable(it) },
+            isLoading = initialTask == null || !isPreviewUsable(initialTask),
+        ),
+    )
+    val state: StateFlow<HabitTaskDetailUiState> = _state.asStateFlow()
+
+    init {
+        loadTask()
+    }
+
+    fun loadTask() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, loadError = null) }
+            habitTaskRepository.getHabitTask(taskId)
+                .onSuccess { task ->
+                    val habitTitle = habitRepository.getHabitById(task.habitId)
+                        .getOrNull()
+                        ?.title
+                        ?.takeIf { it.isNotBlank() }
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            task = task,
+                            habitTitle = habitTitle,
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            loadError = mapNetworkMessage(t),
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun mapNetworkMessage(t: Throwable): String = when (t) {
+        is IOException -> "Sin conexión. Revisa tu red e intenta de nuevo."
+        else -> t.message ?: "No se pudo cargar la tarea."
+    }
+
+    private fun isPreviewUsable(task: HabitTaskDto): Boolean =
+        task.title.isNotBlank() && !task.title.startsWith("Task #")
+
+    class Factory(
+        private val taskId: Int,
+        private val habitTaskRepository: HabitTaskRepository,
+        private val habitRepository: HabitRepository,
+        private val initialTask: HabitTaskDto?,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(HabitTaskDetailViewModel::class.java))
+            return HabitTaskDetailViewModel(
+                taskId,
+                habitTaskRepository,
+                habitRepository,
+                initialTask,
+            ) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskLabels.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskLabels.kt
@@ -1,0 +1,122 @@
+package com.example.leveluplife.ui.habittaskdetail
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.example.leveluplife.R
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.data.network.dto.TimerCriteriaDto
+import com.example.leveluplife.ui.createtask.CreateHabitTaskOptions
+import com.example.leveluplife.ui.createtask.LabeledOption
+
+object HabitTaskLabels {
+
+    private val weekDayCodeToRes = mapOf(
+        "MON" to R.string.weekday_mon,
+        "TUE" to R.string.weekday_tue,
+        "WED" to R.string.weekday_wed,
+        "THU" to R.string.weekday_thu,
+        "FRI" to R.string.weekday_fri,
+        "SAT" to R.string.weekday_sat,
+        "SUN" to R.string.weekday_sun,
+    )
+
+    private val completionCriteria = CreateHabitTaskOptions.completionCriteria + listOf(
+        LabeledOption("TIMER", R.string.create_task_option_criteria_timer),
+    )
+
+    @Composable
+    fun difficulty(value: String): String =
+        CreateHabitTaskOptions.resolveLabel(CreateHabitTaskOptions.difficulties, value)
+            .ifBlank { value }
+
+    @Composable
+    fun frequency(value: String): String =
+        CreateHabitTaskOptions.resolveLabel(CreateHabitTaskOptions.frequencies, value)
+            .ifBlank { value }
+
+    @Composable
+    fun periodUnit(value: String): String =
+        CreateHabitTaskOptions.resolveLabel(CreateHabitTaskOptions.periodUnits, value)
+            .ifBlank { value }
+
+    @Composable
+    fun completionCriteria(value: String): String =
+        CreateHabitTaskOptions.resolveLabel(completionCriteria, value)
+            .ifBlank { value }
+
+    @Composable
+    fun evidence(value: String): String =
+        CreateHabitTaskOptions.resolveLabel(CreateHabitTaskOptions.evidenceTypes, value)
+            .ifBlank { value }
+
+    @Composable
+    fun periodSummary(periodLength: Int, periodUnit: String): String {
+        val unitLabel = when (periodUnit) {
+            "DAYS" -> stringResource(
+                if (periodLength == 1) R.string.period_unit_day else R.string.period_unit_days,
+            )
+            "WEEKS" -> stringResource(
+                if (periodLength == 1) R.string.period_unit_week else R.string.period_unit_weeks,
+            )
+            "MONTHS" -> stringResource(
+                if (periodLength == 1) R.string.period_unit_month else R.string.period_unit_months,
+            )
+            else -> periodUnit(periodUnit).lowercase()
+        }
+        return stringResource(R.string.task_detail_period_value, periodLength, unitLabel)
+    }
+
+    @Composable
+    fun weekDays(raw: String?): String {
+        if (raw.isNullOrBlank()) return ""
+        val codes = raw.split(',')
+            .map { it.trim().uppercase() }
+            .filter { it.isNotEmpty() }
+        val labels = ArrayList<String>(codes.size)
+        for (code in codes) {
+            labels.add(weekDayLabel(code))
+        }
+        return labels.joinToString(", ")
+    }
+
+    @Composable
+    private fun weekDayLabel(code: String): String {
+        val labelRes = weekDayCodeToRes[code] ?: return code
+        return stringResource(labelRes)
+    }
+
+    @Composable
+    fun criteriaGoalSummary(task: HabitTaskDto): String = when (task.completionCriteria) {
+        "REPETITIONS" -> task.repetitionCriteria?.toReadableSummary()
+            ?: stringResource(R.string.task_detail_criteria_missing)
+        "EVIDENCE" -> task.evidence?.let { evidence(it) }
+            ?: stringResource(R.string.task_detail_criteria_missing)
+        "TIMER" -> task.timerCriteria?.let { timerGoal(it) }
+            ?: stringResource(R.string.task_detail_criteria_missing)
+        else -> stringResource(R.string.task_detail_criteria_missing)
+    }
+
+    @Composable
+    fun timerGoal(timer: TimerCriteriaDto): String {
+        val duration = formatTimerDuration(timer.numSecondsDefined)
+        return if (timer.typePauseIsAllowed) {
+            stringResource(R.string.task_detail_timer_with_pause, duration)
+        } else {
+            stringResource(R.string.task_detail_timer_no_pause, duration)
+        }
+    }
+
+    fun formatTimerDuration(seconds: Int): String {
+        if (seconds < 60) return "$seconds s"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        val secs = seconds % 60
+        return when {
+            hours > 0 && minutes > 0 -> "${hours} h ${minutes} min"
+            hours > 0 -> "${hours} h"
+            minutes > 0 && secs > 0 -> "${minutes} min ${secs} s"
+            minutes > 0 -> "${minutes} min"
+            else -> "$secs s"
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -21,6 +21,8 @@ import com.example.leveluplife.ui.createtask.CreateHabitTaskViewModel
 import com.example.leveluplife.ui.habitdetail.HabitDetailScreen
 import com.example.leveluplife.ui.habitdetail.HabitDetailViewModel
 import com.example.leveluplife.ui.habittaskdetail.HabitTaskDetailScreen
+import com.example.leveluplife.ui.updatetask.UpdateHabitTaskScreen
+import com.example.leveluplife.ui.updatetask.UpdateHabitTaskViewModel
 import com.example.leveluplife.ui.home.HomeScreen
 import com.example.leveluplife.ui.home.HomeViewModel
 import com.example.leveluplife.ui.profile.ProfileScreen
@@ -37,12 +39,17 @@ object Routes {
     const val HABIT_DETAIL = "habit_detail/{habitId}"
     const val CREATE_HABIT_TASK = "create_habit_task?habitId={habitId}"
     const val HABIT_TASK_DETAIL = "habit_task_detail/{taskId}"
+    const val EDIT_HABIT_TASK = "edit_habit_task/{taskId}"
 
     fun habitDetail(id: Int) = "habit_detail/$id"
     fun createHabitTask(habitId: Int = -1) = "create_habit_task?habitId=$habitId"
     fun habitTaskDetail(taskId: Int) = "habit_task_detail/$taskId"
+    fun editHabitTask(taskId: Int) = "edit_habit_task/$taskId"
 
     const val ARG_CREATED_TASK_JSON = "created_task_json"
+    const val ARG_TASK_SUCCESS_KIND = "task_success_kind"
+    const val TASK_SUCCESS_CREATED = "created"
+    const val TASK_SUCCESS_UPDATED = "updated"
     const val ARG_SHOW_CONFIRMATION = "show_confirmation"
     const val ARG_DEACTIVATION_MESSAGE = "deactivation_message"
     const val ARG_SESSION_EXPIRED_MESSAGE = "session_expired_message"
@@ -180,6 +187,9 @@ fun AppNavigation(
             HabitDetailScreen(
                 viewModel = vm,
                 onBack = { navController.popBackStack() },
+                onTaskClick = { taskId ->
+                    navController.navigate(Routes.habitTaskDetail(taskId))
+                },
             )
         }
         composable(
@@ -211,6 +221,41 @@ fun AppNavigation(
                         Routes.ARG_CREATED_TASK_JSON,
                         taskJson,
                     )
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        Routes.ARG_TASK_SUCCESS_KIND,
+                        Routes.TASK_SUCCESS_CREATED,
+                    )
+                },
+            )
+        }
+        composable(
+            route = Routes.EDIT_HABIT_TASK,
+            arguments = listOf(navArgument("taskId") { type = NavType.IntType }),
+        ) { backStackEntry ->
+            val taskId = backStackEntry.arguments?.getInt("taskId") ?: return@composable
+            val vm: UpdateHabitTaskViewModel = viewModel(
+                factory = UpdateHabitTaskViewModel.Factory(
+                    taskId,
+                    container.habitRepository,
+                    container.habitTaskRepository,
+                ),
+            )
+            UpdateHabitTaskScreen(
+                viewModel = vm,
+                onBack = { navController.popBackStack() },
+                onTaskUpdated = { task ->
+                    val taskJson = json.encodeToString(HabitTaskDto.serializer(), task)
+                    navController.navigate(Routes.habitTaskDetail(task.id)) {
+                        popUpTo(Routes.editHabitTask(taskId)) { inclusive = true }
+                    }
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        Routes.ARG_CREATED_TASK_JSON,
+                        taskJson,
+                    )
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        Routes.ARG_TASK_SUCCESS_KIND,
+                        Routes.TASK_SUCCESS_UPDATED,
+                    )
                 },
             )
         }
@@ -226,23 +271,38 @@ fun AppNavigation(
             val task = taskJson?.let {
                 runCatching { json.decodeFromString(HabitTaskDto.serializer(), it) }.getOrNull()
             }
+            val successKind = backStackEntry.savedStateHandle.get<String>(Routes.ARG_TASK_SUCCESS_KIND)
+                ?: navController.previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.get<String>(Routes.ARG_TASK_SUCCESS_KIND)
+            val successMessageRes = when (successKind) {
+                Routes.TASK_SUCCESS_UPDATED -> R.string.update_task_success
+                Routes.TASK_SUCCESS_CREATED -> R.string.create_task_success_message
+                else -> null
+            }
             if (task != null && task.id == taskId) {
                 HabitTaskDetailScreen(
                     task = task,
-                    showConfirmation = true,
+                    successMessageRes = successMessageRes,
                     onBack = {
                         navController.popBackStack(Routes.DASHBOARD, inclusive = false)
                     },
                     onDone = {
                         navController.popBackStack(Routes.DASHBOARD, inclusive = false)
                     },
+                    onEdit = if (task.isActive) {
+                        { navController.navigate(Routes.editHabitTask(task.id)) }
+                    } else {
+                        null
+                    },
                 )
             } else {
                 HabitTaskDetailScreen(
                     task = HabitTaskDto(id = taskId, title = "Task #$taskId"),
-                    showConfirmation = false,
+                    successMessageRes = null,
                     onBack = { navController.popBackStack() },
                     onDone = { navController.popBackStack(Routes.DASHBOARD, inclusive = false) },
+                    onEdit = { navController.navigate(Routes.editHabitTask(taskId)) },
                 )
             }
         }

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -21,6 +21,7 @@ import com.example.leveluplife.ui.createtask.CreateHabitTaskViewModel
 import com.example.leveluplife.ui.habitdetail.HabitDetailScreen
 import com.example.leveluplife.ui.habitdetail.HabitDetailViewModel
 import com.example.leveluplife.ui.habittaskdetail.HabitTaskDetailScreen
+import com.example.leveluplife.ui.habittaskdetail.HabitTaskDetailViewModel
 import com.example.leveluplife.ui.updatetask.UpdateHabitTaskScreen
 import com.example.leveluplife.ui.updatetask.UpdateHabitTaskViewModel
 import com.example.leveluplife.ui.home.HomeScreen
@@ -187,8 +188,12 @@ fun AppNavigation(
             HabitDetailScreen(
                 viewModel = vm,
                 onBack = { navController.popBackStack() },
-                onTaskClick = { taskId ->
-                    navController.navigate(Routes.habitTaskDetail(taskId))
+                onTaskClick = { task ->
+                    navController.navigate(Routes.habitTaskDetail(task.id))
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        Routes.ARG_CREATED_TASK_JSON,
+                        json.encodeToString(HabitTaskDto.serializer(), task),
+                    )
                 },
             )
         }
@@ -280,31 +285,23 @@ fun AppNavigation(
                 Routes.TASK_SUCCESS_CREATED -> R.string.create_task_success_message
                 else -> null
             }
-            if (task != null && task.id == taskId) {
-                HabitTaskDetailScreen(
-                    task = task,
-                    successMessageRes = successMessageRes,
-                    onBack = {
-                        navController.popBackStack(Routes.DASHBOARD, inclusive = false)
-                    },
-                    onDone = {
-                        navController.popBackStack(Routes.DASHBOARD, inclusive = false)
-                    },
-                    onEdit = if (task.isActive) {
-                        { navController.navigate(Routes.editHabitTask(task.id)) }
-                    } else {
-                        null
-                    },
-                )
-            } else {
-                HabitTaskDetailScreen(
-                    task = HabitTaskDto(id = taskId, title = "Task #$taskId"),
-                    successMessageRes = null,
-                    onBack = { navController.popBackStack() },
-                    onDone = { navController.popBackStack(Routes.DASHBOARD, inclusive = false) },
-                    onEdit = { navController.navigate(Routes.editHabitTask(taskId)) },
-                )
-            }
+            val vm: HabitTaskDetailViewModel = viewModel(
+                factory = HabitTaskDetailViewModel.Factory(
+                    taskId = taskId,
+                    habitTaskRepository = container.habitTaskRepository,
+                    habitRepository = container.habitRepository,
+                    initialTask = task?.takeIf { it.id == taskId },
+                ),
+            )
+            HabitTaskDetailScreen(
+                viewModel = vm,
+                successMessageRes = successMessageRes,
+                onBack = { navController.popBackStack() },
+                onDone = { navController.popBackStack(Routes.DASHBOARD, inclusive = false) },
+                onEdit = { loadedTask ->
+                    navController.navigate(Routes.editHabitTask(loadedTask.id))
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskScreen.kt
@@ -1,0 +1,131 @@
+package com.example.leveluplife.ui.updatetask
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.leveluplife.R
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.ui.components.LulErrorAlertDialog
+import com.example.leveluplife.ui.createtask.HabitTaskFormBottomBar
+import com.example.leveluplife.ui.createtask.HabitTaskFormContent
+import com.example.leveluplife.ui.theme.DarkBackground
+import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
+import com.example.leveluplife.ui.theme.PurplePrimary
+
+object UpdateHabitTaskTestTags {
+    const val CONFLICT_DIALOG = "update_task_conflict_dialog"
+    const val CONFLICT_RELOAD = "update_task_conflict_reload"
+}
+
+@Composable
+fun UpdateHabitTaskScreen(
+    viewModel: UpdateHabitTaskViewModel,
+    onBack: () -> Unit,
+    onTaskUpdated: (HabitTaskDto) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(state.updatedTask) {
+        state.updatedTask?.let { task ->
+            onTaskUpdated(task)
+            viewModel.consumeUpdatedTask()
+        }
+    }
+
+    if (state.showConflictDialog) {
+        LulErrorAlertDialog(
+            title = stringResource(R.string.update_task_conflict_title),
+            message = stringResource(R.string.update_task_conflict_message),
+            dismissText = stringResource(R.string.update_task_conflict_dismiss),
+            onDismiss = viewModel::dismissConflictDialog,
+            retryText = stringResource(R.string.update_task_conflict_reload),
+            onRetry = {
+                viewModel.dismissConflictDialog()
+                viewModel.loadTask()
+            },
+            retryTestTag = UpdateHabitTaskTestTags.CONFLICT_RELOAD,
+            errorTestTag = UpdateHabitTaskTestTags.CONFLICT_DIALOG,
+        )
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = DarkBackground,
+        bottomBar = {
+            if (!state.isLoading && state.loadError == null) {
+                HabitTaskFormBottomBar(
+                    isSubmitting = state.isSubmitting,
+                    enabled = !state.isSubmitting,
+                    submitLabelRes = R.string.update_task_submit,
+                    onSubmit = viewModel::submit,
+                )
+            }
+        },
+    ) { innerPadding ->
+        when {
+            state.isLoading -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = PurplePrimary, modifier = Modifier.size(44.dp))
+            }
+
+            state.loadError != null -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(state.loadError ?: "", color = DarkOnSurfaceVariant)
+                    Spacer(Modifier.height(12.dp))
+                    TextButton(onClick = viewModel::loadTask) {
+                        Text(stringResource(R.string.create_task_retry), color = PurplePrimary)
+                    }
+                }
+            }
+
+            else -> HabitTaskFormContent(
+                form = state.form,
+                contentPadding = innerPadding,
+                onBack = onBack,
+                showTemplates = false,
+                showHabitPicker = false,
+                onHabitSelected = {},
+                onTitleChange = viewModel::onTitleChange,
+                onDescriptionChange = viewModel::onDescriptionChange,
+                onDifficultyChange = viewModel::onDifficultyChange,
+                onFrequencyChange = viewModel::onFrequencyChange,
+                onPeriodLengthChange = viewModel::onPeriodLengthChange,
+                onPeriodUnitChange = viewModel::onPeriodUnitChange,
+                onStartDateChange = viewModel::onStartDateChange,
+                onCompletionCriteriaChange = viewModel::onCompletionCriteriaChange,
+                onRepetitionsChange = viewModel::onRepetitionsChange,
+                onMeasurementUnitChange = viewModel::onMeasurementUnitChange,
+                onEvidenceChange = viewModel::onEvidenceChange,
+                onPartialAllowedChange = viewModel::onPartialAllowedChange,
+                onApplyTemplate = {},
+                onDismissError = viewModel::dismissSubmitError,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskUiState.kt
@@ -5,6 +5,7 @@ import com.example.leveluplife.ui.createtask.HabitTaskFormState
 
 data class UpdateHabitTaskUiState(
     val form: HabitTaskFormState = HabitTaskFormState(),
+    val originalStartDate: String? = null,
     val isLoading: Boolean = true,
     val loadError: String? = null,
     val isSubmitting: Boolean = false,

--- a/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskUiState.kt
@@ -1,0 +1,13 @@
+package com.example.leveluplife.ui.updatetask
+
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.ui.createtask.HabitTaskFormState
+
+data class UpdateHabitTaskUiState(
+    val form: HabitTaskFormState = HabitTaskFormState(),
+    val isLoading: Boolean = true,
+    val loadError: String? = null,
+    val isSubmitting: Boolean = false,
+    val updatedTask: HabitTaskDto? = null,
+    val showConflictDialog: Boolean = false,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModel.kt
@@ -7,6 +7,7 @@ import com.example.leveluplife.data.habits.HabitRepository
 import com.example.leveluplife.data.habits.HabitTaskConflictFailure
 import com.example.leveluplife.data.habits.HabitTaskRepository
 import com.example.leveluplife.data.habits.HabitTaskValidationFailure
+import com.example.leveluplife.domain.validation.HabitTaskValidationOptions
 import com.example.leveluplife.domain.validation.HabitTaskValidators
 import com.example.leveluplife.ui.createtask.HabitTaskFormHandlers
 import com.example.leveluplife.ui.createtask.HabitTaskFormState
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.IOException
+import java.time.LocalDate
 
 class UpdateHabitTaskViewModel(
     private val taskId: Int,
@@ -44,6 +46,7 @@ class UpdateHabitTaskViewModel(
                         it.copy(
                             isLoading = false,
                             form = HabitTaskFormState.fromTask(task, habits),
+                            originalStartDate = task.startDate.trim(),
                         )
                     }
                 }
@@ -120,7 +123,14 @@ class UpdateHabitTaskViewModel(
 
     fun submit() {
         val sanitizedForm = _state.value.form.sanitizedForValidation()
-        val errors = HabitTaskValidators.validateForm(sanitizedForm.toFormInput())
+        val validationOptions = HabitTaskValidationOptions(
+            today = LocalDate.now(),
+            preservedStartDate = _state.value.originalStartDate,
+        )
+        val errors = HabitTaskValidators.validateForm(
+            sanitizedForm.toFormInput(),
+            validationOptions,
+        )
         if (errors.hasErrors) {
             _state.update {
                 it.copy(
@@ -153,7 +163,13 @@ class UpdateHabitTaskViewModel(
             _state.update { it.copy(isSubmitting = true, form = it.form.copy(submitError = null)) }
             habitTaskRepository.updateHabitTask(taskId, request)
                 .onSuccess { task ->
-                    _state.update { it.copy(isSubmitting = false, updatedTask = task) }
+                    _state.update {
+                        it.copy(
+                            isSubmitting = false,
+                            updatedTask = task,
+                            originalStartDate = task.startDate.trim(),
+                        )
+                    }
                 }
                 .onFailure { t ->
                     when (t) {

--- a/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModel.kt
@@ -1,70 +1,61 @@
-package com.example.leveluplife.ui.createtask
+package com.example.leveluplife.ui.updatetask
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.leveluplife.data.habits.HabitRepository
+import com.example.leveluplife.data.habits.HabitTaskConflictFailure
 import com.example.leveluplife.data.habits.HabitTaskRepository
 import com.example.leveluplife.data.habits.HabitTaskValidationFailure
 import com.example.leveluplife.domain.validation.HabitTaskValidators
+import com.example.leveluplife.ui.createtask.HabitTaskFormHandlers
+import com.example.leveluplife.ui.createtask.HabitTaskFormState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.IOException
-import java.time.LocalDate
 
-class CreateHabitTaskViewModel(
+class UpdateHabitTaskViewModel(
+    private val taskId: Int,
     private val habitRepository: HabitRepository,
     private val habitTaskRepository: HabitTaskRepository,
-    preselectedHabitId: Int?,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(
-        CreateHabitTaskUiState(
-            form = HabitTaskFormState(
-                selectedHabitId = preselectedHabitId?.takeIf { it > 0 },
-                startDate = LocalDate.now().toString(),
-            ),
-        ),
-    )
-    val state: StateFlow<CreateHabitTaskUiState> = _state.asStateFlow()
+    private val _state = MutableStateFlow(UpdateHabitTaskUiState())
+    val state: StateFlow<UpdateHabitTaskUiState> = _state.asStateFlow()
 
     init {
-        loadHabits()
+        loadTask()
     }
 
-    fun loadHabits() {
+    fun loadTask() {
         viewModelScope.launch {
-            _state.update { it.copy(isLoadingHabits = true, habitsLoadError = null) }
-            habitRepository.getActiveHabits(page = 1)
-                .onSuccess { response ->
-                    val habits = response.habits.orEmpty()
-                    _state.update { current ->
-                        val selected = current.form.selectedHabitId ?: habits.firstOrNull()?.id
-                        current.copy(
-                            isLoadingHabits = false,
-                            form = current.form.copy(
-                                habits = habits,
-                                selectedHabitId = selected,
-                            ),
+            _state.update { it.copy(isLoading = true, loadError = null, showConflictDialog = false) }
+
+            val habitsResult = habitRepository.getActiveHabits(page = 1)
+            val taskResult = habitTaskRepository.getHabitTask(taskId)
+
+            val habits = habitsResult.getOrNull()?.habits.orEmpty()
+            taskResult
+                .onSuccess { task ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            form = HabitTaskFormState.fromTask(task, habits),
                         )
                     }
                 }
                 .onFailure { t ->
                     _state.update {
                         it.copy(
-                            isLoadingHabits = false,
-                            habitsLoadError = mapNetworkMessage(t),
+                            isLoading = false,
+                            loadError = mapNetworkMessage(t),
                         )
                     }
                 }
         }
-    }
-
-    fun onHabitSelected(habitId: Int) {
-        _state.update { it.copy(form = HabitTaskFormHandlers.onHabitSelected(it.form, habitId)) }
     }
 
     fun onTitleChange(value: String) {
@@ -115,16 +106,16 @@ class CreateHabitTaskViewModel(
         _state.update { it.copy(form = it.form.copy(isPartialAllowed = value)) }
     }
 
-    fun applyTemplate(template: TaskFormTemplate) {
-        _state.update { it.copy(form = HabitTaskFormState.applyTemplate(it.form, template)) }
-    }
-
     fun dismissSubmitError() {
         _state.update { it.copy(form = it.form.copy(submitError = null)) }
     }
 
-    fun consumeCreatedTask() {
-        _state.update { it.copy(createdTask = null) }
+    fun dismissConflictDialog() {
+        _state.update { it.copy(showConflictDialog = false) }
+    }
+
+    fun consumeUpdatedTask() {
+        _state.update { it.copy(updatedTask = null) }
     }
 
     fun submit() {
@@ -160,9 +151,9 @@ class CreateHabitTaskViewModel(
 
         viewModelScope.launch {
             _state.update { it.copy(isSubmitting = true, form = it.form.copy(submitError = null)) }
-            habitTaskRepository.createHabitTask(request)
+            habitTaskRepository.updateHabitTask(taskId, request)
                 .onSuccess { task ->
-                    _state.update { it.copy(isSubmitting = false, createdTask = task) }
+                    _state.update { it.copy(isSubmitting = false, updatedTask = task) }
                 }
                 .onFailure { t ->
                     when (t) {
@@ -174,6 +165,13 @@ class CreateHabitTaskViewModel(
                                     showValidationErrors = true,
                                     submitError = null,
                                 ),
+                            )
+                        }
+                        is HabitTaskConflictFailure -> _state.update {
+                            it.copy(
+                                isSubmitting = false,
+                                showConflictDialog = true,
+                                form = it.form.copy(submitError = null),
                             )
                         }
                         else -> _state.update {
@@ -194,22 +192,18 @@ class CreateHabitTaskViewModel(
 
     private fun mapSubmitError(t: Throwable): String = when (t) {
         is IOException -> "Sin conexión. Revisa tu red e intenta de nuevo."
-        else -> t.message ?: "No se pudo crear la tarea."
+        else -> t.message ?: "No se pudo actualizar la tarea."
     }
 
     class Factory(
+        private val taskId: Int,
         private val habitRepository: HabitRepository,
         private val habitTaskRepository: HabitTaskRepository,
-        private val preselectedHabitId: Int?,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            require(modelClass.isAssignableFrom(CreateHabitTaskViewModel::class.java))
-            return CreateHabitTaskViewModel(
-                habitRepository,
-                habitTaskRepository,
-                preselectedHabitId,
-            ) as T
+            require(modelClass.isAssignableFrom(UpdateHabitTaskViewModel::class.java))
+            return UpdateHabitTaskViewModel(taskId, habitRepository, habitTaskRepository) as T
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,16 @@
     <string name="create_task_error_evidence_required">Selecciona un tipo de evidencia</string>
     <string name="create_task_success_message">¡Tarea creada correctamente!</string>
 
+    <string name="update_task_title">Editar tarea</string>
+    <string name="update_task_subtitle">Actualizá los requisitos de la tarea</string>
+    <string name="update_task_submit">Guardar cambios</string>
+    <string name="update_task_success">¡Tarea actualizada correctamente!</string>
+    <string name="update_task_edit">Editar</string>
+    <string name="update_task_conflict_title">Conflicto al guardar</string>
+    <string name="update_task_conflict_message">La tarea cambió en otro lugar. Recargá los datos para ver la versión más reciente e intentá de nuevo.</string>
+    <string name="update_task_conflict_reload">Recargar</string>
+    <string name="update_task_conflict_dismiss">Cancelar</string>
+
     <!-- Task detail -->
     <string name="task_detail_title">Detalle de la tarea</string>
     <string name="task_detail_meta">%1$s · %2$s · inicio %3$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,7 +68,8 @@
     <string name="create_task_field_period_length">Duración</string>
     <string name="create_task_field_period_unit">Periodo</string>
     <string name="create_task_field_start_date">Fecha de inicio</string>
-    <string name="create_task_start_date_hint">Formato AAAA-MM-DD · ej. 2026-05-26</string>
+    <string name="create_task_start_date_hint">Formato AAAA-MM-DD · hoy o una fecha futura</string>
+    <string name="update_task_start_date_hint">Si no la cambiás, se mantiene la fecha original. Al modificarla, elegí hoy o una fecha futura.</string>
     <string name="create_task_partial_allowed">Permitir progreso parcial</string>
     <string name="create_task_preview_title">Vista previa</string>
     <string name="create_task_preview_no_description">Sin descripción</string>
@@ -79,6 +80,8 @@
     <string name="create_task_category_unknown">Sin categoría</string>
     <string name="create_task_option_criteria_repetitions">Repeticiones</string>
     <string name="create_task_option_criteria_timer">Cronómetro</string>
+    <string name="create_task_field_timer_seconds">Duración (segundos)</string>
+    <string name="create_task_timer_pause_allowed">Pausas permitidas</string>
     <string name="create_task_option_criteria_evidence">Evidencia</string>
     <string name="create_task_option_unit_reps">Repeticiones</string>
     <string name="create_task_option_unit_series">Series</string>
@@ -99,6 +102,8 @@
     <string name="create_task_option_period_months">Meses</string>
     <string name="create_task_error_invalid_number">Valor numérico inválido</string>
     <string name="create_task_error_invalid_date">Fecha inválida. Usá el formato AAAA-MM-DD</string>
+    <string name="create_task_error_past_date">La fecha de inicio no puede ser anterior a hoy</string>
+    <string name="create_task_error_invalid_option">Selección inválida</string>
     <string name="create_task_error_criteria_required">Completa los criterios de repetición</string>
     <string name="create_task_error_evidence_required">Selecciona un tipo de evidencia</string>
     <string name="create_task_success_message">¡Tarea creada correctamente!</string>
@@ -116,8 +121,41 @@
     <!-- Task detail -->
     <string name="task_detail_title">Detalle de la tarea</string>
     <string name="task_detail_meta">%1$s · %2$s · inicio %3$s</string>
+    <string name="task_detail_planning_section">PLANIFICACIÓN</string>
     <string name="task_detail_criteria_section">CRITERIOS</string>
+    <string name="task_detail_criteria_goal">Meta</string>
+    <string name="task_detail_criteria_missing">Sin detalle configurado</string>
+    <string name="task_detail_criteria_inactive">Criterio inactivo</string>
+    <string name="task_detail_plan_duration">Duración del plan</string>
+    <string name="task_detail_period_value">%1$d %2$s</string>
+    <string name="task_detail_xp">Experiencia</string>
+    <string name="task_detail_xp_value">%1$d XP</string>
+    <string name="task_detail_week_days">Días de la semana</string>
+    <string name="weekday_mon">Lun</string>
+    <string name="weekday_tue">Mar</string>
+    <string name="weekday_wed">Mié</string>
+    <string name="weekday_thu">Jue</string>
+    <string name="weekday_fri">Vie</string>
+    <string name="weekday_sat">Sáb</string>
+    <string name="weekday_sun">Dom</string>
+    <string name="period_unit_day">día</string>
+    <string name="period_unit_days">días</string>
+    <string name="period_unit_week">semana</string>
+    <string name="period_unit_weeks">semanas</string>
+    <string name="period_unit_month">mes</string>
+    <string name="period_unit_months">meses</string>
+    <string name="task_detail_status_active">Activa</string>
+    <string name="task_detail_status_inactive">Inactiva</string>
+    <string name="task_detail_status_completed">Completada</string>
+    <string name="task_detail_untitled">Tarea sin título</string>
+    <string name="task_detail_timer_with_pause">%1$s (pausas permitidas)</string>
+    <string name="task_detail_timer_no_pause">%1$s (sin pausas)</string>
     <string name="task_detail_back_home">Volver al inicio</string>
+
+    <string name="habit_detail_task_subtitle">%1$s · %2$s · %3$s</string>
+    <string name="habit_detail_task_default_title">Tarea %1$d</string>
+    <string name="habit_detail_tasks_section">TAREAS Y CRITERIOS</string>
+    <string name="habit_detail_with_criteria">%1$d con criterios</string>
 
     <!-- Settings / deactivate account -->
     <string name="settings_title">Ajustes</string>

--- a/app/src/test/java/com/example/leveluplife/domain/validation/HabitTaskValidatorsTest.kt
+++ b/app/src/test/java/com/example/leveluplife/domain/validation/HabitTaskValidatorsTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.LocalDate
 
 class HabitTaskValidatorsTest {
 
@@ -35,10 +36,12 @@ class HabitTaskValidatorsTest {
                 completionCriteria = "TIMER",
                 repetitions = "",
                 measurementUnit = null,
+                timerSecondsDefined = "1800",
             ),
         )
         assertNull(errors.repetitions)
         assertNull(errors.measurementUnit)
+        assertNull(errors.timerSeconds)
     }
 
     @Test
@@ -65,11 +68,69 @@ class HabitTaskValidatorsTest {
     }
 
     @Test
+    fun `incomplete start date returns InvalidDate`() {
+        val error = HabitTaskValidators.validateStartDate("2026-05-2")
+        assertEquals(HabitTaskFieldError.InvalidDate, error)
+    }
+
+    @Test
+    fun `past start date returns PastDate`() {
+        val error = HabitTaskValidators.validateStartDate(
+            value = "2020-01-01",
+            options = HabitTaskValidationOptions(today = LocalDate.of(2026, 5, 26)),
+        )
+        assertEquals(HabitTaskFieldError.PastDate, error)
+    }
+
+    @Test
+    fun `preserved start date allows past date on edit`() {
+        val error = HabitTaskValidators.validateStartDate(
+            value = "2020-01-01",
+            options = HabitTaskValidationOptions(
+                today = LocalDate.of(2026, 5, 26),
+                preservedStartDate = "2020-01-01",
+            ),
+        )
+        assertNull(error)
+    }
+
+    @Test
+    fun `changed start date to past returns PastDate even with preserved original`() {
+        val error = HabitTaskValidators.validateStartDate(
+            value = "2021-06-15",
+            options = HabitTaskValidationOptions(
+                today = LocalDate.of(2026, 5, 26),
+                preservedStartDate = "2020-01-01",
+            ),
+        )
+        assertEquals(HabitTaskFieldError.PastDate, error)
+    }
+
+    @Test
+    fun `invalid difficulty returns InvalidOption`() {
+        val errors = HabitTaskValidators.validateForm(
+            validRepetitionsForm().copy(difficulty = "SUPER_HARD"),
+        )
+        assertEquals(HabitTaskFieldError.InvalidOption, errors.difficulty)
+    }
+
+    @Test
     fun `blank period length is required`() {
         val errors = HabitTaskValidators.validateForm(
             validRepetitionsForm().copy(periodLength = ""),
         )
         assertEquals(HabitTaskFieldError.Required, errors.periodLength)
+    }
+
+    @Test
+    fun `TIMER requires timer seconds`() {
+        val errors = HabitTaskValidators.validateForm(
+            validRepetitionsForm().copy(
+                completionCriteria = "TIMER",
+                timerSecondsDefined = "",
+            ),
+        )
+        assertEquals(HabitTaskFieldError.CriteriaRequired, errors.timerSeconds)
     }
 
     private fun validRepetitionsForm() = HabitTaskFormInput(
@@ -86,5 +147,6 @@ class HabitTaskValidatorsTest {
         measurementUnit = "SERIES",
         evidence = null,
         isPartialAllowed = true,
+        timerSecondsDefined = "",
     )
 }

--- a/app/src/test/java/com/example/leveluplife/ui/createtask/CreateHabitTaskViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/createtask/CreateHabitTaskViewModelTest.kt
@@ -138,5 +138,13 @@ class CreateHabitTaskViewModelTest {
             createCalls++
             return result
         }
+
+        override suspend fun getHabitTask(taskId: Int): Result<HabitTaskDto> =
+            Result.failure(UnsupportedOperationException())
+
+        override suspend fun updateHabitTask(
+            taskId: Int,
+            request: CreateHabitTaskRequest,
+        ): Result<HabitTaskDto> = Result.failure(UnsupportedOperationException())
     }
 }

--- a/app/src/test/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModelTest.kt
@@ -9,6 +9,7 @@ import com.example.leveluplife.data.network.dto.HabitTaskDto
 import com.example.leveluplife.data.network.dto.HabitsPageResponse
 import com.example.leveluplife.data.network.dto.PaginationDto
 import com.example.leveluplife.data.network.dto.RepetitionCriteriaDto
+import com.example.leveluplife.domain.validation.HabitTaskFieldError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -90,6 +91,42 @@ class UpdateHabitTaskViewModelTest {
     }
 
     @Test
+    fun `submit without changing original start date allows save even if date is in the past`() = runTest(testDispatcher) {
+        val task = sampleTask(title = "Original", startDate = "2026-05-20")
+        val updated = task.copy(title = "Solo título cambiado")
+        val taskRepo = FakeHabitTaskRepository(task = task, updateResult = Result.success(updated))
+        val vm = UpdateHabitTaskViewModel(42, FakeHabitRepository(), taskRepo)
+
+        advanceUntilIdle()
+
+        vm.onTitleChange("Solo título cambiado")
+        vm.submit()
+
+        advanceUntilIdle()
+
+        assertEquals(1, taskRepo.updateCalls)
+        assertEquals(updated, vm.state.value.updatedTask)
+        assertNull(vm.state.value.form.fieldErrors.startDate)
+    }
+
+    @Test
+    fun `submit with past start date shows validation error`() = runTest(testDispatcher) {
+        val taskRepo = FakeHabitTaskRepository(task = sampleTask())
+        val vm = UpdateHabitTaskViewModel(42, FakeHabitRepository(), taskRepo)
+
+        advanceUntilIdle()
+
+        vm.onStartDateChange("2020-01-01")
+        vm.submit()
+
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.form.showValidationErrors)
+        assertEquals(HabitTaskFieldError.PastDate, vm.state.value.form.fieldErrors.startDate)
+        assertEquals(0, taskRepo.updateCalls)
+    }
+
+    @Test
     fun `409 conflict shows dialog`() = runTest(testDispatcher) {
         val taskRepo = FakeHabitTaskRepository(
             task = sampleTask(),
@@ -108,7 +145,7 @@ class UpdateHabitTaskViewModelTest {
         assertNull(vm.state.value.updatedTask)
     }
 
-    private fun sampleTask(title: String = "Tarea") = HabitTaskDto(
+    private fun sampleTask(title: String = "Tarea", startDate: String = "2026-05-26") = HabitTaskDto(
         id = 42,
         habitId = 1,
         title = title,
@@ -117,7 +154,7 @@ class UpdateHabitTaskViewModelTest {
         frequency = "WEEKLY",
         periodLength = 1,
         periodUnit = "WEEKS",
-        startDate = "2026-05-26",
+        startDate = startDate,
         completionCriteria = "REPETITIONS",
         repetitionCriteria = RepetitionCriteriaDto(
             repetitions = 3,

--- a/app/src/test/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModelTest.kt
@@ -1,0 +1,171 @@
+package com.example.leveluplife.ui.updatetask
+
+import com.example.leveluplife.data.habits.HabitRepository
+import com.example.leveluplife.data.habits.HabitTaskConflictFailure
+import com.example.leveluplife.data.habits.HabitTaskRepository
+import com.example.leveluplife.data.network.dto.CreateHabitTaskRequest
+import com.example.leveluplife.data.network.dto.HabitDto
+import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.data.network.dto.HabitsPageResponse
+import com.example.leveluplife.data.network.dto.PaginationDto
+import com.example.leveluplife.data.network.dto.RepetitionCriteriaDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateHabitTaskViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `loadTask populates form from repository`() = runTest(testDispatcher) {
+        val task = sampleTask(title = "Original")
+        val vm = UpdateHabitTaskViewModel(42, FakeHabitRepository(), FakeHabitTaskRepository(task = task))
+
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertFalse(state.isLoading)
+        assertNull(state.loadError)
+        assertEquals("Original", state.form.title)
+        assertEquals(1, state.form.selectedHabitId)
+    }
+
+    @Test
+    fun `submit with valid form calls update and emits updated task`() = runTest(testDispatcher) {
+        val task = sampleTask(title = "Original")
+        val updated = task.copy(title = "Actualizada")
+        val taskRepo = FakeHabitTaskRepository(task = task, updateResult = Result.success(updated))
+        val vm = UpdateHabitTaskViewModel(42, FakeHabitRepository(), taskRepo)
+
+        advanceUntilIdle()
+
+        vm.onTitleChange("Actualizada")
+        vm.submit()
+
+        advanceUntilIdle()
+
+        assertEquals(1, taskRepo.updateCalls)
+        assertEquals(updated, vm.state.value.updatedTask)
+        assertFalse(vm.state.value.isSubmitting)
+    }
+
+    @Test
+    fun `submit with invalid form shows validation errors and skips repository`() = runTest(testDispatcher) {
+        val taskRepo = FakeHabitTaskRepository(task = sampleTask())
+        val vm = UpdateHabitTaskViewModel(42, FakeHabitRepository(), taskRepo)
+
+        advanceUntilIdle()
+
+        vm.onTitleChange("")
+        vm.submit()
+
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.form.showValidationErrors)
+        assertEquals(0, taskRepo.updateCalls)
+    }
+
+    @Test
+    fun `409 conflict shows dialog`() = runTest(testDispatcher) {
+        val taskRepo = FakeHabitTaskRepository(
+            task = sampleTask(),
+            updateResult = Result.failure(HabitTaskConflictFailure("conflict")),
+        )
+        val vm = UpdateHabitTaskViewModel(42, FakeHabitRepository(), taskRepo)
+
+        advanceUntilIdle()
+
+        vm.submit()
+
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.showConflictDialog)
+        assertFalse(vm.state.value.isSubmitting)
+        assertNull(vm.state.value.updatedTask)
+    }
+
+    private fun sampleTask(title: String = "Tarea") = HabitTaskDto(
+        id = 42,
+        habitId = 1,
+        title = title,
+        description = "Desc",
+        difficulty = "MEDIUM",
+        frequency = "WEEKLY",
+        periodLength = 1,
+        periodUnit = "WEEKS",
+        startDate = "2026-05-26",
+        completionCriteria = "REPETITIONS",
+        repetitionCriteria = RepetitionCriteriaDto(
+            repetitions = 3,
+            measurementUnit = "SERIES",
+            isPartialAllowed = true,
+        ),
+    )
+
+    private class FakeHabitRepository : HabitRepository {
+        override suspend fun getActiveHabits(page: Int, pageSize: Int): Result<HabitsPageResponse> =
+            Result.success(
+                HabitsPageResponse(
+                    success = true,
+                    habits = listOf(
+                        HabitDto(
+                            id = 1,
+                            title = "Rutina de Fuerza Semanal",
+                            categoryName = "Salud",
+                            disciplineName = "Ejercicio",
+                            isActive = true,
+                        ),
+                    ),
+                    pagination = PaginationDto(1, 10, 1, 1),
+                ),
+            )
+
+        override suspend fun getHabitById(id: Int): Result<HabitDto> =
+            Result.failure(UnsupportedOperationException())
+    }
+
+    private class FakeHabitTaskRepository(
+        private val task: HabitTaskDto,
+        private val updateResult: Result<HabitTaskDto> = Result.success(task),
+    ) : HabitTaskRepository {
+        var updateCalls = 0
+
+        override suspend fun createHabitTask(request: CreateHabitTaskRequest): Result<HabitTaskDto> =
+            Result.failure(UnsupportedOperationException())
+
+        override suspend fun getHabitTask(taskId: Int): Result<HabitTaskDto> =
+            if (taskId == task.id) Result.success(task) else Result.failure(Exception("not found"))
+
+        override suspend fun updateHabitTask(
+            taskId: Int,
+            request: CreateHabitTaskRequest,
+        ): Result<HabitTaskDto> {
+            updateCalls++
+            return updateResult
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

Implements the full **habit task edit** flow on Android by reusing the create-task form, wired to `GET` and `PUT /api/habit-tasks/{id}`.

Also includes task detail improvements, shared create/edit validation, **409** conflict handling, navigation from task and habit detail screens, and ViewModel tests.

### Data layer
- `HabitTasksApi`: `getHabitTask(id)` and `updateHabitTask(id, body)`.
- `HabitTaskRepository`: `getHabitTask`, `updateHabitTask`, `HabitTaskConflictFailure` (409), and 400 error mapping via `HabitTaskApiErrorParser`.
- DTOs: `timerCriteria` support in request/response with `@SerialName` aligned to the backend (`NUM_SECONDS_DEFINED`, etc.).

### Shared form
- `HabitTaskFormState`: unified state with `fromTask()`, `toRequest()`, `sanitizedForValidation()`, and `HabitTaskFormHandlers` (input sanitization).
- `CreateHabitTaskScreen` refactored: `HabitTaskFormContent` + `HabitTaskFormBottomBar` reused for create and edit.
- On edit: habit category is read-only; **TIMER** tasks show criteria and seconds as read-only (not editable from the form).

### Edit screen (`ui/updatetask/`)
- `UpdateHabitTaskViewModel`: loads task + active habits, validates, and sends `PUT`.
- `UpdateHabitTaskScreen`: reuses the shared form; bottom bar with “Save changes”.
- **409** dialog: conflict message with **Reload** (re-fetches via `GET`) and **Cancel** actions.
- `originalStartDate`: allows saving without changing the start date even if it is before today; only enforces a future/today date when the user modifies it.

### Navigation
- Route `edit_habit_task/{taskId}` in `AppNavigation`.
- **Edit** button on `HabitTaskDetailScreen` (active tasks only).
- Clickable tasks on `HabitDetailScreen` → task detail → edit.

### Task detail (related improvements)
- `HabitTaskDetailViewModel`: always loads from `GET /api/habit-tasks/{id}` (no reliance on navigation JSON).
- `HabitTaskLabels`: Spanish UI labels for difficulty, frequency, criteria, timer, etc.
- Week days translated (`MON,TUE,…` → `Lun, Mar, Mié, …`).
- Plan duration pluralization (`1 día` vs `2 días`).
- Removed misleading green check that confused `isActive` with completed state.

### Validation & sanitization (create + edit)
- Start date: `YYYY-MM-DD` format, valid calendar date, not in the past on create or when changed on edit.
- Option validation (difficulty, frequency, units, criteria, evidence).
- Numeric limits for period length, repetitions, and timer seconds.
- Real-time sanitization: title, description, ISO date, numeric fields.

### Local connectivity (dev)
- `HostProvider`: on emulator, rewrites private LAN IPs to `10.0.2.2` while preserving the port.
- Default API port updated to **5147** in `build.gradle.kts`.

---

## 🎯 Purpose

Closes the gap in **#25**: users could create habit tasks but could not edit them from the app.

This PR lets users update existing tasks with the same UX as creation, handles backend concurrency conflicts (409), and shows a richer, API-backed task detail screen with localized labels.

---

## 🔄 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests

**Manual testing:**
- Local backend (`dotnet run --urls "http://0.0.0.0:5147"`) + Postgres Docker (`leveluplife-postgres` on port 5433).
- Physical device over USB: `adb reverse tcp:5147 tcp:5147` + `api.host=localhost:5147` in `local.properties`.
- Create task → view detail → **Edit** → save changes.
- Edit from task list on habit detail screen.
- Edit title only without changing a past start date (should allow save).
- Change start date to a past date (should show validation error).
- Trigger/simulate 409 → reload/cancel dialog.
- TIMER task: read-only criteria; save without `timerCriteria` errors.
- Task detail: week days in Spanish, singular duration (“1 día”).

**Unit tests:**
- `UpdateHabitTaskViewModelTest`: form load, successful submit, validation blocks submit, past date rejected, original start date preserved, 409 dialog.
- `HabitTaskValidatorsTest`: invalid/incomplete dates, past dates, preserved date on edit, TIMER/EVIDENCE/REPETITIONS criteria, invalid options.

---

## 📸 Screenshots (if applicable)

<img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/0417c9c4-00a2-40ff-b434-c5665608d3d5" />
<img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/9884a79e-c30b-4acc-88b2-068cdcbe080d" />
<img width="771" height="1600" alt="image" src="https://github.com/user-attachments/assets/e1e13a3a-ad5c-49e6-91d5-0e9611a836f6" />

---

## 🚀 Deployment Notes (if needed)

- Requires backend with `GET/PUT api/habit-tasks/{id}` endpoints available.
- No migration or production env var changes.
- `local.properties` remains gitignored; each developer configures `api.host` for emulator/physical device.

---

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if necessary
- [x] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #25  
Linked to #25