### PR TITLE
Upload task evidence

### DIFF
--- a/app/src/main/java/com/example/leveluplife/AppContainer.kt
+++ b/app/src/main/java/com/example/leveluplife/AppContainer.kt
@@ -103,7 +103,7 @@ class AppContainer(applicationContext: Context) {
     }
 
     val evidenceRepository: EvidenceRepository by lazy {
-        DefaultEvidenceRepository(api = habitTasksApi)
+        DefaultEvidenceRepository(api = habitTasksApi, context = appContext)
     }
 
     val playerRepository: PlayerRepository by lazy {

--- a/app/src/main/java/com/example/leveluplife/data/habits/EvidenceRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/habits/EvidenceRepository.kt
@@ -1,13 +1,32 @@
 package com.example.leveluplife.data.habits
 
+import android.content.Context
+import android.net.Uri
 import com.example.leveluplife.data.network.HabitTasksApi
+import com.example.leveluplife.data.network.dto.CreateEvidenceRequest
 import com.example.leveluplife.data.network.dto.EvidenceDto
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 interface EvidenceRepository {
     suspend fun getTaskEvidences(taskId: Int): Result<List<EvidenceDto>>
+    suspend fun uploadEvidence(
+        taskId: Int,
+        fileUri: String,
+        mimeType: String?,
+        healthDataJson: String? = null,
+    ): Result<EvidenceDto>
 }
 
-class DefaultEvidenceRepository(private val api: HabitTasksApi) : EvidenceRepository {
+class DefaultEvidenceRepository(
+    private val api: HabitTasksApi,
+    private val context: Context,
+) : EvidenceRepository {
 
     override suspend fun getTaskEvidences(taskId: Int): Result<List<EvidenceDto>> = try {
         val response = api.getTaskEvidences(taskId)
@@ -18,5 +37,90 @@ class DefaultEvidenceRepository(private val api: HabitTasksApi) : EvidenceReposi
         }
     } catch (t: Throwable) {
         Result.failure(t)
+    }
+
+    override suspend fun uploadEvidence(
+        taskId: Int,
+        fileUri: String,
+        mimeType: String?,
+        healthDataJson: String?,
+    ): Result<EvidenceDto> {
+        return try {
+            // Step 1: upload the file to get a hosted URL
+            val fileUrl = uploadFile(fileUri, mimeType).getOrElse { return Result.failure(it) }
+
+            // Step 2: create the evidence record with the URL
+            val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+            sdf.timeZone = TimeZone.getTimeZone("UTC")
+            val fecUploaded = sdf.format(Date())
+
+            val request = CreateEvidenceRequest(
+                url = fileUrl,
+                healthDataJson = healthDataJson?.takeIf { it.isNotBlank() },
+                uploadedAt = fecUploaded,
+            )
+
+            val response = api.createEvidence(taskId, request)
+            when {
+                response.isSuccessful -> {
+                    val body = response.body()
+                        ?: return Result.failure(Exception("empty_response"))
+                    Result.success(body)
+                }
+                response.code() == 400 -> {
+                    val errorBody = response.errorBody()?.string() ?: ""
+                    Result.failure(Exception("upload_invalid_fields|$errorBody"))
+                }
+                response.code() == 404 -> Result.failure(Exception("task_not_found"))
+                else -> {
+                    val errorBody = response.errorBody()?.string() ?: ""
+                    Result.failure(Exception("HTTP ${response.code()}|$errorBody"))
+                }
+            }
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
+    }
+
+    private suspend fun uploadFile(fileUri: String, mimeType: String?): Result<String> {
+        return try {
+            val uri = Uri.parse(fileUri)
+            val resolver = context.contentResolver
+            val contentType = mimeType?.takeIf { it.isNotBlank() }
+                ?: resolver.getType(uri)
+                ?: "image/jpeg"
+            val bytes = resolver.openInputStream(uri)?.use { it.readBytes() }
+                ?: return Result.failure(Exception("cannot_read_file"))
+            if (bytes.isEmpty()) return Result.failure(Exception("cannot_read_file"))
+
+            val extension = when {
+                contentType.contains("png") -> "png"
+                contentType.contains("webp") -> "webp"
+                contentType.contains("mp4") -> "mp4"
+                contentType.contains("pdf") -> "pdf"
+                else -> "jpg"
+            }
+
+            val filePart = MultipartBody.Part.createFormData(
+                "file",
+                "evidence.$extension",
+                bytes.toRequestBody(contentType.toMediaType()),
+            )
+
+            val response = api.uploadEvidenceFile(filePart)
+            when {
+                response.isSuccessful -> {
+                    val url = response.body()?.url
+                        ?: return Result.failure(Exception("empty_upload_response"))
+                    Result.success(url)
+                }
+                else -> {
+                    val errorBody = response.errorBody()?.string() ?: ""
+                    Result.failure(Exception("upload_file_failed|HTTP ${response.code()}|$errorBody"))
+                }
+            }
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
     }
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitTasksApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitTasksApi.kt
@@ -1,15 +1,20 @@
 package com.example.leveluplife.data.network
 
+import com.example.leveluplife.data.network.dto.CreateEvidenceRequest
 import com.example.leveluplife.data.network.dto.CreateHabitTaskRequest
 import com.example.leveluplife.data.network.dto.DeactivateHabitTaskResponse
 import com.example.leveluplife.data.network.dto.EvidenceDto
+import com.example.leveluplife.data.network.dto.EvidenceFileUploadResponse
 import com.example.leveluplife.data.network.dto.HabitTaskDto
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Part
 import retrofit2.http.Path
 
 interface HabitTasksApi {
@@ -18,6 +23,18 @@ interface HabitTasksApi {
 
     @GET("api/habit-tasks/{taskId}/evidences")
     suspend fun getTaskEvidences(@Path("taskId") taskId: Int): Response<List<EvidenceDto>>
+
+    @POST("api/habit-tasks/{taskId}/evidences")
+    suspend fun createEvidence(
+        @Path("taskId") taskId: Int,
+        @Body body: CreateEvidenceRequest,
+    ): Response<EvidenceDto>
+
+    @Multipart
+    @POST("api/evidences/upload")
+    suspend fun uploadEvidenceFile(
+        @Part file: MultipartBody.Part,
+    ): Response<EvidenceFileUploadResponse>
 
     @GET("api/habit-tasks/{taskId}")
     suspend fun getHabitTask(@Path("taskId") taskId: Int): Response<HabitTaskDto>

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/CreateEvidenceRequest.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/CreateEvidenceRequest.kt
@@ -1,0 +1,16 @@
+package com.example.leveluplife.data.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateEvidenceRequest(
+    @SerialName("DSC_EVIDENCE_PATH_URL") val url: String? = null,
+    @SerialName("DSC_HEALTH_DATA_JSON") val healthDataJson: String? = null,
+    @SerialName("FEC_UPLOADED") val uploadedAt: String,
+)
+
+@Serializable
+data class EvidenceFileUploadResponse(
+    @SerialName("url") val url: String,
+)

--- a/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryScreen.kt
@@ -1,5 +1,7 @@
 package com.example.leveluplife.ui.evidence
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,19 +21,25 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BrokenImage
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,6 +53,7 @@ import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.example.leveluplife.R
 import com.example.leveluplife.data.network.dto.EvidenceDto
+import com.example.leveluplife.ui.components.showLulSnackbar
 import com.example.leveluplife.ui.theme.DarkBackground
 import com.example.leveluplife.ui.theme.DarkOnBackground
 import com.example.leveluplife.ui.theme.DarkOnSurfaceVariant
@@ -58,10 +67,67 @@ fun EvidenceGalleryScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    val pickImage = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri ->
+        if (uri != null) {
+            val mimeType = context.contentResolver.getType(uri)
+            viewModel.uploadEvidence(uri.toString(), mimeType)
+        }
+    }
+
+    val successMessage = stringResource(R.string.evidence_upload_success)
+    val errorGenericMessage = stringResource(R.string.evidence_upload_error_generic)
+    val errorInvalidMessage = stringResource(R.string.evidence_upload_error_invalid)
+    val errorFileMessage = stringResource(R.string.evidence_upload_error_file)
+    val errorTaskNotFoundMessage = stringResource(R.string.evidence_gallery_error_not_found)
+
+    LaunchedEffect(state.uploadSuccess) {
+        if (state.uploadSuccess) {
+            snackbarHostState.showLulSnackbar(successMessage)
+            viewModel.onUploadSuccessShown()
+        }
+    }
+
+    LaunchedEffect(state.uploadError) {
+        val error = state.uploadError ?: return@LaunchedEffect
+        val message = when {
+            error == "cannot_read_file" -> errorFileMessage
+            error.startsWith("upload_invalid_fields") -> errorInvalidMessage
+            error == "task_not_found" -> errorTaskNotFoundMessage
+            else -> "$errorGenericMessage ($error)"
+        }
+        snackbarHostState.showLulSnackbar(message, durationMillis = 5_000L)
+        viewModel.onUploadErrorShown()
+    }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = DarkBackground,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { if (!state.isUploading) pickImage.launch("image/*") },
+                containerColor = PurplePrimary,
+                contentColor = DarkOnBackground,
+            ) {
+                if (state.isUploading) {
+                    CircularProgressIndicator(
+                        color = DarkOnBackground,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(24.dp),
+                    )
+                } else {
+                    Icon(
+                        Icons.Filled.Add,
+                        contentDescription = stringResource(R.string.evidence_upload_button),
+                    )
+                }
+            }
+        },
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryUiState.kt
@@ -6,4 +6,7 @@ data class EvidenceGalleryUiState(
     val isLoading: Boolean = true,
     val evidences: List<EvidenceDto> = emptyList(),
     val error: String? = null,
+    val isUploading: Boolean = false,
+    val uploadError: String? = null,
+    val uploadSuccess: Boolean = false,
 )

--- a/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryViewModel.kt
@@ -35,6 +35,33 @@ class EvidenceGalleryViewModel(
         }
     }
 
+    fun uploadEvidence(fileUri: String, mimeType: String?) {
+        viewModelScope.launch {
+            _state.update { it.copy(isUploading = true, uploadError = null) }
+            repository.uploadEvidence(taskId, fileUri, mimeType)
+                .onSuccess { evidence ->
+                    _state.update { state ->
+                        state.copy(
+                            isUploading = false,
+                            evidences = listOf(evidence) + state.evidences,
+                            uploadSuccess = true,
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update { it.copy(isUploading = false, uploadError = t.message) }
+                }
+        }
+    }
+
+    fun onUploadSuccessShown() {
+        _state.update { it.copy(uploadSuccess = false) }
+    }
+
+    fun onUploadErrorShown() {
+        _state.update { it.copy(uploadError = null) }
+    }
+
     class Factory(
         private val repository: EvidenceRepository,
         private val taskId: Int,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,13 @@
     <string name="evidence_gallery_uploaded_on">Subido el %1$s</string>
     <string name="evidence_gallery_view_button">Ver evidencias</string>
 
+    <!-- Evidence upload -->
+    <string name="evidence_upload_button">Subir evidencia</string>
+    <string name="evidence_upload_success">Evidencia subida correctamente</string>
+    <string name="evidence_upload_error_generic">No se pudo subir la evidencia. Intentá de nuevo.</string>
+    <string name="evidence_upload_error_invalid">Datos inválidos. Verificá el archivo seleccionado.</string>
+    <string name="evidence_upload_error_file">No se pudo leer el archivo seleccionado.</string>
+
 
     <string name="update_task_title">Editar tarea</string>
     <string name="update_task_subtitle">Actualizá los requisitos de la tarea</string>


### PR DESCRIPTION
# 📌 Pull Request

## 📖 Description

 Implements the evidence upload flow from the `EvidenceGalleryScreen`. The user selects an image from the device gallery, the app uploads the file to the backend and immediately registers the resulting URL as a new evidence record for the task. The new evidence is prepended to the gallery grid without requiring a manual reload.

---

## 🎯 Purpose

Users needed a way to attach photographic evidence to a habit task directly from the evidence gallery screen. Previously the screen was read-only; this PR adds the full write path.

---

## 🔄 Type of Change

Please check the relevant option:

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🔧 Other (please describe):

---

## 🧪 How Has This Been Tested?

Describe the tests you ran and how you verified your changes.

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Explain the testing process:
  1. Navigate to a habit task → tap "Ver evidencias"
  2. Tap the FAB (+) → system image picker opens
  3. Select an image → FAB switches to a spinner while uploading
  4. On success: snackbar "Evidencia subida correctamente" appears and the new evidence card is prepended to the grid
  5. On backend error: snackbar shows the HTTP status code received
  6. Verified the FAB is disabled during upload to prevent duplicate submissions
  7. Verified the existing GET evidences flow has no regressions
---

## 📸 Screenshots (if applicable)

<img width="1862" height="1151" alt="imagen" src="https://github.com/user-attachments/assets/57e6f6b1-edb5-4b20-9b4b-ec7792111c2b" />
<img width="1886" height="1146" alt="imagen" src="https://github.com/user-attachments/assets/9a4f4682-85f1-429f-9ccf-4e8c7191028c" />


---

## 🚀 Deployment Notes (if needed)

N/A

---

## ✅ Checklist

Before requesting a review, please confirm:

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have tested my changes thoroughly
- [X] I have updated documentation if necessary
- [X] My changes do not introduce new warnings or errors

---

## 🧩 Related Issues

Closes #38 
