### PR TITLE
feat: add habit soft delete from home screen

### DIFF
--- a/app/src/main/java/com/example/leveluplife/data/habits/HabitRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/habits/HabitRepository.kt
@@ -13,6 +13,7 @@ interface HabitRepository {
     suspend fun getActiveHabits(page: Int, pageSize: Int = 10): Result<HabitsPageResponse>
     suspend fun createHabit(request: CreateHabitRequestDto): Result<CreateHabitResponseDto>
     suspend fun updateHabit(request: UpdateHabitRequestDto): Result<CreateHabitResponseDto>
+    suspend fun deleteHabit(habitId: Int): Result<Unit>
     suspend fun getHabitById(id: Int): Result<HabitDto>
     fun setCurrentUserId(userId: Int)
     fun getCurrentUserId(): Int
@@ -81,6 +82,19 @@ class DefaultHabitRepository(
                 val summary = HabitTaskApiErrorParser.parse400(errorBody).summary
                 Result.failure(Exception("Validación fallida: $summary"))
             }
+            response.code() == 401 -> Result.failure(Exception("Sesión expirada. Inicia sesión de nuevo."))
+            response.code() == 404 -> Result.failure(Exception("Hábito no encontrado"))
+            response.code() == 500 -> Result.failure(Exception("Error del servidor: ${response.body()?.message}"))
+            else -> Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (t: Throwable) {
+        Result.failure(t)
+    }
+
+    override suspend fun deleteHabit(habitId: Int): Result<Unit> = try {
+        val response = api.deleteHabit(habitId)
+        when {
+            response.isSuccessful -> Result.success(Unit)
             response.code() == 401 -> Result.failure(Exception("Sesión expirada. Inicia sesión de nuevo."))
             response.code() == 404 -> Result.failure(Exception("Hábito no encontrado"))
             response.code() == 500 -> Result.failure(Exception("Error del servidor: ${response.body()?.message}"))

--- a/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/HabitsApi.kt
@@ -7,6 +7,7 @@ import com.example.leveluplife.data.network.dto.CreateHabitResponseDto
 import com.example.leveluplife.data.network.dto.UpdateHabitRequestDto
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -31,4 +32,7 @@ interface HabitsApi {
         @Path("id") id: Int,
         @Body body: UpdateHabitRequestDto,
     ): Response<CreateHabitResponseDto>
+
+    @DELETE("api/habits/{id}")
+    suspend fun deleteHabit(@Path("id") id: Int): Response<CreateHabitResponseDto>
 }

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +37,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Person
@@ -83,6 +85,7 @@ import com.example.leveluplife.R
 import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.player.PlayerProfile
 import com.example.leveluplife.data.player.ProfileCache
+import com.example.leveluplife.ui.components.LulConfirmAlertDialog
 import java.util.Calendar
 
 private val StreakInactive = Color(0xFF6B7280)
@@ -106,6 +109,15 @@ fun HomeScreen(
     val state by viewModel.state.collectAsState()
     val cachedProfile by profileCache.profile.collectAsState()
     val listState = rememberLazyListState()
+    val context = LocalContext.current
+    var habitPendingDelete by remember { mutableStateOf<HabitDto?>(null) }
+
+    LaunchedEffect(state.deleteError) {
+        state.deleteError?.let { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            viewModel.onDeleteErrorShown()
+        }
+    }
 
     val shouldLoadMore by remember {
         derivedStateOf {
@@ -223,6 +235,7 @@ fun HomeScreen(
                         HabitCard(
                             habit = habit,
                             onClick = { onHabitClick(habit.id) },
+                            onDelete = { habitPendingDelete = habit },
                         )
                         Spacer(Modifier.height(10.dp))
                     }
@@ -244,6 +257,20 @@ fun HomeScreen(
                 }
             }
         }
+    }
+
+    habitPendingDelete?.let { habit ->
+        LulConfirmAlertDialog(
+            title = stringResource(R.string.home_delete_habit_title),
+            message = stringResource(R.string.home_delete_habit_message, habit.title),
+            confirmText = stringResource(R.string.home_delete_habit_confirm),
+            dismissText = stringResource(R.string.home_delete_habit_cancel),
+            onConfirm = {
+                viewModel.deleteHabit(habit.id)
+                habitPendingDelete = null
+            },
+            onDismiss = { habitPendingDelete = null },
+        )
     }
 }
 
@@ -578,6 +605,7 @@ private fun CalendarWeekCard() {
 private fun HabitCard(
     habit: HabitDto,
     onClick: () -> Unit,
+    onDelete: () -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(14.dp),
@@ -587,7 +615,7 @@ private fun HabitCard(
             .clickable(onClick = onClick),
     ) {
         Row(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, bottom = 16.dp, end = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
@@ -624,6 +652,19 @@ private fun HabitCard(
                     )
                 }
             }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier
+                    .align(Alignment.Top)
+                    .size(36.dp),
+            ) {
+                Icon(
+                    Icons.Filled.Delete,
+                    contentDescription = stringResource(R.string.home_delete_habit_action),
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
         }
     }
 }
@@ -646,6 +687,7 @@ private fun HomeBottomBar(onOpenSettings: () -> Unit, onOpenCoach: () -> Unit) {
     NavigationBar(
         containerColor = MaterialTheme.colorScheme.surface,
         tonalElevation = 0.dp,
+        windowInsets = WindowInsets(0, 0, 0, 0),
     ) {
         items.forEach { item ->
             NavigationBarItem(

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeUiState.kt
@@ -10,4 +10,6 @@ data class HomeUiState(
     val currentPage: Int = 1,
     val totalPages: Int = 1,
     val hasMore: Boolean = false,
+    val deletingHabitId: Int? = null,
+    val deleteError: String? = null,
 )

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeViewModel.kt
@@ -83,6 +83,33 @@ class HomeViewModel(
         }
     }
 
+    fun deleteHabit(habitId: Int) {
+        viewModelScope.launch {
+            _state.update { it.copy(deletingHabitId = habitId, deleteError = null) }
+            habitRepository.deleteHabit(habitId)
+                .onSuccess {
+                    _state.update {
+                        it.copy(
+                            deletingHabitId = null,
+                            habits = it.habits.filter { habit -> habit.id != habitId },
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update {
+                        it.copy(
+                            deletingHabitId = null,
+                            deleteError = t.message ?: "No se pudo eliminar el hábito",
+                        )
+                    }
+                }
+        }
+    }
+
+    fun onDeleteErrorShown() {
+        _state.update { it.copy(deleteError = null) }
+    }
+
     class Factory(
         private val habitRepository: HabitRepository,
         private val profileRepository: ProfileRepository,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,13 @@
     <string name="habit_detail_description_field">Descripción (opcional)</string>
     <string name="habit_detail_update_success">Hábito actualizado</string>
 
+    <!-- Home: eliminar hábito -->
+    <string name="home_delete_habit_action">Eliminar hábito</string>
+    <string name="home_delete_habit_title">Eliminar hábito</string>
+    <string name="home_delete_habit_message">¿Seguro que deseas eliminar «%1$s»? Se eliminarán también todas sus tareas.</string>
+    <string name="home_delete_habit_confirm">Eliminar</string>
+    <string name="home_delete_habit_cancel">Cancelar</string>
+
     <!-- Settings / deactivate account -->
     <string name="settings_title">Ajustes</string>
     <string name="settings_back">Volver</string>

--- a/app/src/test/java/com/example/leveluplife/ui/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/auth/LoginViewModelTest.kt
@@ -230,6 +230,9 @@ class LoginViewModelTest {
         override suspend fun updateHabit(request: UpdateHabitRequestDto): Result<CreateHabitResponseDto> =
             Result.failure(IllegalStateException("not configured"))
 
+        override suspend fun deleteHabit(habitId: Int): Result<Unit> =
+            Result.failure(IllegalStateException("not configured"))
+
         override suspend fun getHabitById(id: Int): Result<HabitDto> =
             Result.failure(IllegalStateException("not configured"))
 

--- a/app/src/test/java/com/example/leveluplife/ui/createtask/CreateHabitTaskViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/createtask/CreateHabitTaskViewModelTest.kt
@@ -135,6 +135,9 @@ class CreateHabitTaskViewModelTest {
         override suspend fun updateHabit(request: UpdateHabitRequestDto): Result<CreateHabitResponseDto> =
             Result.failure(UnsupportedOperationException())
 
+        override suspend fun deleteHabit(habitId: Int): Result<Unit> =
+            Result.failure(UnsupportedOperationException())
+
         override fun setCurrentUserId(userId: Int) = Unit
 
         override fun getCurrentUserId(): Int = 1

--- a/app/src/test/java/com/example/leveluplife/ui/habitdetail/HabitDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/habitdetail/HabitDetailViewModelTest.kt
@@ -84,6 +84,9 @@ class HabitDetailViewModelTest {
         override suspend fun updateHabit(request: UpdateHabitRequestDto): Result<CreateHabitResponseDto> =
             Result.failure(UnsupportedOperationException())
 
+        override suspend fun deleteHabit(habitId: Int): Result<Unit> =
+            Result.failure(UnsupportedOperationException())
+
         override fun setCurrentUserId(userId: Int) = Unit
 
         override fun getCurrentUserId(): Int = 1

--- a/app/src/test/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModelTest.kt
@@ -384,6 +384,9 @@ class HabitTaskDetailViewModelTest {
         override suspend fun updateHabit(request: UpdateHabitRequestDto): Result<CreateHabitResponseDto> =
             Result.failure(UnsupportedOperationException())
 
+        override suspend fun deleteHabit(habitId: Int): Result<Unit> =
+            Result.failure(UnsupportedOperationException())
+
         override fun setCurrentUserId(userId: Int) = Unit
 
         override fun getCurrentUserId(): Int = 1

--- a/app/src/test/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/updatetask/UpdateHabitTaskViewModelTest.kt
@@ -243,6 +243,9 @@ class UpdateHabitTaskViewModelTest {
         override suspend fun updateHabit(request: UpdateHabitRequestDto): Result<CreateHabitResponseDto> =
             Result.failure(UnsupportedOperationException())
 
+        override suspend fun deleteHabit(habitId: Int): Result<Unit> =
+            Result.failure(UnsupportedOperationException())
+
         override fun setCurrentUserId(userId: Int) = Unit
 
         override fun getCurrentUserId(): Int = 1


### PR DESCRIPTION
## 📖 Description

  Adds the **soft delete habit** action to the home screen. Each habit card now has
  a red trash button in its top-right corner; tapping it opens a confirmation
  dialog, and confirming soft-deletes the habit via `DELETE /api/habits/{id}` and
  removes it from the list. The confirmation message warns that the habit's tasks
  will be deleted too.

  Also fixes a layout issue where the bottom navigation bar was floating above the
  system navigation bar.

  ---

  ## 🎯 Purpose

  Users had no way to remove a habit from the app. This adds a quick, safe delete
  flow (with confirmation) directly from the habit list, consuming the new backend
  soft-delete endpoint that also deactivates the habit's tasks.

  ---

  ## 🔄 Type of Change

  - [x] ✨ New feature
  - [x] 🐛 Bug fix
  - [ ] ♻️ Refactor
  - [ ] 📝 Documentation update
  - [ ] ⚡ Performance improvement
  - [ ] 🔧 Other (please describe):

  ---

  ## 🧪 How Has This Been Tested?

  - [x] Manual testing
  - [ ] Unit tests
  - [ ] Integration tests


  - `:app:compileDebugKotlin` builds successfully.
  - Manual end-to-end on the Android app:
    - Tapping the trash button on a habit shows the confirmation dialog.
    - Confirming removes the habit from the list; cancelling leaves it untouched.
    - On a backend/network error the habit stays in the list and a Toast is shown.
    - Verified the bottom navigation bar now sits flush above the system
      navigation bar (no floating gap) in both light and dark mode.

  ---

  ## 📸 Screenshots (if applicable)
  
<img width="388" height="828" alt="image" src="https://github.com/user-attachments/assets/26c7aa7e-154e-48e2-9f93-5b4c9c1a8880" />

<img width="414" height="747" alt="image" src="https://github.com/user-attachments/assets/edcfde01-b7c3-4e49-b693-57098a9d8b0e" />

  
  ---

  ## 🚀 Deployment Notes (if needed)

  - Requires the backend soft-delete endpoint `DELETE /api/habits/{id}` (sends the
    `X-User-Id` header via the existing auth interceptor).

  ---
  
  ## ✅ Checklist
  
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  - [ ] I have updated documentation if necessary
  - [x] My changes do not introduce new warnings or errors

  ---
  
  ## 🧩 Related Issues

  Closes #11 
  Linked to #11 