### PR TITLE
feat: read Health Connect data as task evidence

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.health.connect.client)
 
     implementation(libs.retrofit)
     implementation(libs.retrofit.kotlinx.serialization.converter)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,17 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+    <uses-permission android:name="android.permission.health.READ_DISTANCE" />
+    <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+
+    <uses-sdk tools:overrideLibrary="androidx.health.connect.client" />
+
+    <queries>
+        <package android:name="com.google.android.apps.healthdata" />
+    </queries>
+
     <application
         android:name=".LevelUpLifeApp"
         android:allowBackup="true"
@@ -30,7 +41,21 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="androidx.health.connect.action.SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
         </activity>
+
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:targetActivity=".MainActivity"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/leveluplife/AppContainer.kt
+++ b/app/src/main/java/com/example/leveluplife/AppContainer.kt
@@ -41,6 +41,7 @@ import com.example.leveluplife.data.player.ProfileCache
 import com.example.leveluplife.data.player.ProfileRepository
 import com.example.leveluplife.data.preferences.DebugApiPreferences
 import com.example.leveluplife.data.preferences.ThemePreferences
+import com.example.leveluplife.health.HealthConnectManager
 import com.example.leveluplife.ui.theme.ThemeController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -120,6 +121,10 @@ class AppContainer(applicationContext: Context) {
 
     val evidenceRepository: EvidenceRepository by lazy {
         DefaultEvidenceRepository(api = habitTasksApi, context = appContext)
+    }
+
+    val healthConnectManager: HealthConnectManager by lazy {
+        HealthConnectManager(appContext)
     }
 
     val chatStorage: ChatStorage by lazy { ChatStorage(appContext) }

--- a/app/src/main/java/com/example/leveluplife/data/habits/EvidenceRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/habits/EvidenceRepository.kt
@@ -22,6 +22,7 @@ interface EvidenceRepository {
         mimeType: String?,
         healthDataJson: String? = null,
     ): Result<EvidenceDto>
+    suspend fun addHealthEvidence(taskId: Int, healthDataJson: String): Result<EvidenceDto>
 }
 
 class DefaultEvidenceRepository(
@@ -91,6 +92,28 @@ class DefaultEvidenceRepository(
         } catch (t: Throwable) {
             Result.failure(t)
         }
+    }
+
+    override suspend fun addHealthEvidence(taskId: Int, healthDataJson: String): Result<EvidenceDto> = try {
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+        sdf.timeZone = TimeZone.getTimeZone("UTC")
+        val request = CreateEvidenceRequest(
+            url = null,
+            healthDataJson = healthDataJson,
+            uploadedAt = sdf.format(Date()),
+        )
+        val response = api.createEvidence(taskId, request)
+        when {
+            response.isSuccessful -> {
+                val body = response.body() ?: return Result.failure(Exception("empty_response"))
+                Result.success(body)
+            }
+            response.code() == 400 -> Result.failure(Exception("upload_invalid_fields"))
+            response.code() == 404 -> Result.failure(Exception("task_not_found"))
+            else -> Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (t: Throwable) {
+        Result.failure(t)
     }
 
     private suspend fun uploadFile(fileUri: String, mimeType: String?): Result<String> {

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/EvidenceDto.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/EvidenceDto.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class EvidenceDto(
     @SerialName("id") val id: Int,
     @SerialName("habitTaskId") val taskId: Int,
-    @SerialName("url") val url: String,
+    @SerialName("url") val url: String? = null,
     @SerialName("healthDataJson") val healthDataJson: String? = null,
     @SerialName("uploadedAt") val uploadedAt: String,
 )

--- a/app/src/main/java/com/example/leveluplife/health/HealthConnectManager.kt
+++ b/app/src/main/java/com/example/leveluplife/health/HealthConnectManager.kt
@@ -1,0 +1,74 @@
+package com.example.leveluplife.health
+
+import android.content.Context
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
+import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class HealthConnectManager(private val context: Context) {
+
+    enum class Metric { STEPS, DISTANCE, CALORIES, EXERCISE }
+
+    data class Reading(val metric: Metric, val value: Double, val unit: String)
+
+    val permissions: Set<String> = setOf(
+        HealthPermission.getReadPermission(StepsRecord::class),
+        HealthPermission.getReadPermission(DistanceRecord::class),
+        HealthPermission.getReadPermission(ActiveCaloriesBurnedRecord::class),
+        HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+    )
+
+    fun isAvailable(): Boolean =
+        HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE
+
+    suspend fun hasAllPermissions(): Boolean {
+        if (!isAvailable()) return false
+        val granted = HealthConnectClient.getOrCreate(context)
+            .permissionController
+            .getGrantedPermissions()
+        return granted.containsAll(permissions)
+    }
+
+    suspend fun readTodayTotal(metric: Metric): Reading {
+        val client = HealthConnectClient.getOrCreate(context)
+        val zone = ZoneId.systemDefault()
+        val start = LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        val range = TimeRangeFilter.between(start, Instant.now())
+
+        return when (metric) {
+            Metric.STEPS -> {
+                val result = client.aggregate(AggregateRequest(setOf(StepsRecord.COUNT_TOTAL), range))
+                Reading(metric, (result[StepsRecord.COUNT_TOTAL] ?: 0L).toDouble(), "steps")
+            }
+            Metric.DISTANCE -> {
+                val result = client.aggregate(AggregateRequest(setOf(DistanceRecord.DISTANCE_TOTAL), range))
+                Reading(metric, result[DistanceRecord.DISTANCE_TOTAL]?.inKilometers ?: 0.0, "km")
+            }
+            Metric.CALORIES -> {
+                val result = client.aggregate(
+                    AggregateRequest(setOf(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL), range),
+                )
+                Reading(metric, result[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories ?: 0.0, "kcal")
+            }
+            Metric.EXERCISE -> {
+                val result = client.aggregate(
+                    AggregateRequest(setOf(ExerciseSessionRecord.EXERCISE_DURATION_TOTAL), range),
+                )
+                Reading(metric, (result[ExerciseSessionRecord.EXERCISE_DURATION_TOTAL]?.toMinutes() ?: 0L).toDouble(), "min")
+            }
+        }
+    }
+
+    fun toHealthDataJson(reading: Reading): String {
+        val date = LocalDate.now().toString()
+        return """{"metric":"${reading.metric.name}","value":${reading.value},"unit":"${reading.unit}","date":"$date"}"""
+    }
+}

--- a/app/src/main/java/com/example/leveluplife/health/HealthEvidencePayload.kt
+++ b/app/src/main/java/com/example/leveluplife/health/HealthEvidencePayload.kt
@@ -1,0 +1,11 @@
+package com.example.leveluplife.health
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HealthEvidencePayload(
+    val metric: String = "",
+    val value: Double = 0.0,
+    val unit: String = "",
+    val date: String = "",
+)

--- a/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BrokenImage
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -43,7 +44,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,10 +58,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.health.connect.client.PermissionController
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.example.leveluplife.R
 import com.example.leveluplife.data.network.dto.EvidenceDto
+import com.example.leveluplife.health.HealthConnectManager
+import com.example.leveluplife.health.HealthEvidencePayload
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import java.util.Locale
 import com.example.leveluplife.ui.components.LulErrorAlertDialog
 import com.example.leveluplife.ui.components.showLulSnackbar
 import com.example.leveluplife.ui.theme.DarkBackground
@@ -67,6 +77,25 @@ import com.example.leveluplife.ui.theme.DarkSurfaceVariant
 import com.example.leveluplife.ui.theme.PurplePrimary
 
 private val DangerRed = Color(0xFFCF6679)
+private val HealthJson = Json { ignoreUnknownKeys = true }
+
+private fun formatHealthValue(value: Double): String =
+    if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.2f", value)
+
+@Composable
+private fun healthEvidenceLabel(healthDataJson: String): String {
+    val payload = remember(healthDataJson) {
+        runCatching { HealthJson.decodeFromString<HealthEvidencePayload>(healthDataJson) }.getOrNull()
+    } ?: return healthDataJson
+    val value = formatHealthValue(payload.value)
+    return when (payload.metric) {
+        "STEPS" -> stringResource(R.string.evidence_health_value_steps, value)
+        "DISTANCE" -> stringResource(R.string.evidence_health_value_distance, value)
+        "CALORIES" -> stringResource(R.string.evidence_health_value_calories, value)
+        "EXERCISE" -> stringResource(R.string.evidence_health_value_exercise, value)
+        else -> stringResource(R.string.evidence_health_value_generic, value, payload.unit)
+    }
+}
 
 @Composable
 fun EvidenceGalleryScreen(
@@ -78,6 +107,8 @@ fun EvidenceGalleryScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
+    val scope = rememberCoroutineScope()
+
     val pickImage = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent(),
     ) { uri ->
@@ -87,12 +118,36 @@ fun EvidenceGalleryScreen(
         }
     }
 
+    var showMetricPicker by remember { mutableStateOf(false) }
+    var pendingMetric by remember { mutableStateOf<HealthConnectManager.Metric?>(null) }
+    val healthUnavailableMessage = stringResource(R.string.evidence_health_unavailable)
+    val healthPermissionDeniedMessage = stringResource(R.string.evidence_health_permission_denied)
+
+    val healthPermissionLauncher = rememberLauncherForActivityResult(
+        contract = PermissionController.createRequestPermissionResultContract(),
+    ) { granted ->
+        val metric = pendingMetric
+        pendingMetric = null
+        if (metric != null && granted.containsAll(viewModel.healthPermissions)) {
+            viewModel.syncHealthMetric(metric)
+        } else {
+            scope.launch { snackbarHostState.showLulSnackbar(healthPermissionDeniedMessage) }
+        }
+    }
+
+    val onPickMetric: (HealthConnectManager.Metric) -> Unit = { metric ->
+        showMetricPicker = false
+        pendingMetric = metric
+        healthPermissionLauncher.launch(viewModel.healthPermissions)
+    }
+
     val deleteSuccessMessage = stringResource(R.string.evidence_gallery_delete_success)
     val successMessage = stringResource(R.string.evidence_upload_success)
     val errorGenericMessage = stringResource(R.string.evidence_upload_error_generic)
     val errorInvalidMessage = stringResource(R.string.evidence_upload_error_invalid)
     val errorFileMessage = stringResource(R.string.evidence_upload_error_file)
     val errorTaskNotFoundMessage = stringResource(R.string.evidence_gallery_error_not_found)
+    val errorHealthReadMessage = stringResource(R.string.evidence_health_read_failed)
 
     LaunchedEffect(state.deleteSuccess) {
         if (state.deleteSuccess) {
@@ -114,6 +169,7 @@ fun EvidenceGalleryScreen(
             error == "cannot_read_file" -> errorFileMessage
             error.startsWith("upload_invalid_fields") -> errorInvalidMessage
             error == "task_not_found" -> errorTaskNotFoundMessage
+            error == "health_read_failed" -> errorHealthReadMessage
             else -> "$errorGenericMessage ($error)"
         }
         snackbarHostState.showLulSnackbar(message, durationMillis = 5_000L)
@@ -148,13 +204,57 @@ fun EvidenceGalleryScreen(
         )
     }
 
+    if (showMetricPicker) {
+        AlertDialog(
+            onDismissRequest = { showMetricPicker = false },
+            title = { Text(stringResource(R.string.evidence_health_pick_title)) },
+            text = {
+                Column {
+                    TextButton(
+                        onClick = { onPickMetric(HealthConnectManager.Metric.STEPS) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text(stringResource(R.string.evidence_health_metric_steps)) }
+                    TextButton(
+                        onClick = { onPickMetric(HealthConnectManager.Metric.DISTANCE) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text(stringResource(R.string.evidence_health_metric_distance)) }
+                    TextButton(
+                        onClick = { onPickMetric(HealthConnectManager.Metric.CALORIES) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text(stringResource(R.string.evidence_health_metric_calories)) }
+                    TextButton(
+                        onClick = { onPickMetric(HealthConnectManager.Metric.EXERCISE) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text(stringResource(R.string.evidence_health_metric_exercise)) }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showMetricPicker = false }) {
+                    Text(stringResource(R.string.evidence_health_cancel))
+                }
+            },
+        )
+    }
+
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = DarkBackground,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { if (!state.isUploading) pickImage.launch("image/*") },
+                onClick = {
+                    if (state.isUploading) return@FloatingActionButton
+                    if (viewModel.isHealthConnectTask) {
+                        if (viewModel.isHealthConnectAvailable) {
+                            showMetricPicker = true
+                        } else {
+                            scope.launch { snackbarHostState.showLulSnackbar(healthUnavailableMessage) }
+                        }
+                    } else {
+                        pickImage.launch(viewModel.galleryMimeType)
+                    }
+                },
                 containerColor = PurplePrimary,
                 contentColor = DarkOnBackground,
             ) {
@@ -272,34 +372,52 @@ private fun EvidenceCard(
         colors = CardDefaults.cardColors(containerColor = DarkSurfaceVariant),
     ) {
         Column {
-            SubcomposeAsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(evidence.url)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                error = {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9f)
-                            .background(DarkBackground),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            Icons.Filled.BrokenImage,
-                            contentDescription = null,
-                            tint = DarkOnSurfaceVariant,
-                            modifier = Modifier.size(32.dp),
-                        )
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(16f / 9f)
-                    .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
-            )
+            if (!evidence.url.isNullOrBlank()) {
+                SubcomposeAsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(evidence.url)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    error = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(16f / 9f)
+                                .background(DarkBackground),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Filled.BrokenImage,
+                                contentDescription = null,
+                                tint = DarkOnSurfaceVariant,
+                                modifier = Modifier.size(32.dp),
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(16f / 9f)
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(16f / 9f)
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                        .background(DarkBackground),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Filled.MonitorHeart,
+                        contentDescription = null,
+                        tint = PurplePrimary,
+                        modifier = Modifier.size(32.dp),
+                    )
+                }
+            }
 
             Column(modifier = Modifier.padding(start = 10.dp, end = 4.dp, top = 8.dp, bottom = 4.dp)) {
                 Text(
@@ -313,9 +431,10 @@ private fun EvidenceCard(
                 if (!evidence.healthDataJson.isNullOrBlank()) {
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = evidence.healthDataJson,
-                        fontSize = 10.sp,
-                        color = DarkOnSurfaceVariant,
+                        text = healthEvidenceLabel(evidence.healthDataJson),
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = DarkOnBackground,
                         maxLines = 2,
                     )
                 }

--- a/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/evidence/EvidenceGalleryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.leveluplife.data.habits.EvidenceRepository
 import com.example.leveluplife.data.network.dto.EvidenceDto
+import com.example.leveluplife.health.HealthConnectManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,10 +16,17 @@ class EvidenceGalleryViewModel(
     private val repository: EvidenceRepository,
     private val taskId: Int,
     private val isTaskCompleted: Boolean,
+    private val healthConnectManager: HealthConnectManager,
+    evidenceType: String?,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(EvidenceGalleryUiState())
     val state: StateFlow<EvidenceGalleryUiState> = _state.asStateFlow()
+
+    val isHealthConnectTask: Boolean = evidenceType == "HEALTH_CONNECT"
+    val isHealthConnectAvailable: Boolean = healthConnectManager.isAvailable()
+    val healthPermissions: Set<String> = healthConnectManager.permissions
+    val galleryMimeType: String = if (evidenceType == "VIDEO") "video/*" else "image/*"
 
     init {
         load()
@@ -107,6 +115,30 @@ class EvidenceGalleryViewModel(
         }
     }
 
+    fun syncHealthMetric(metric: HealthConnectManager.Metric) {
+        viewModelScope.launch {
+            _state.update { it.copy(isUploading = true, uploadError = null) }
+            val reading = runCatching { healthConnectManager.readTodayTotal(metric) }.getOrNull()
+            if (reading == null) {
+                _state.update { it.copy(isUploading = false, uploadError = "health_read_failed") }
+                return@launch
+            }
+            repository.addHealthEvidence(taskId, healthConnectManager.toHealthDataJson(reading))
+                .onSuccess { evidence ->
+                    _state.update { state ->
+                        state.copy(
+                            isUploading = false,
+                            evidences = listOf(evidence) + state.evidences,
+                            uploadSuccess = true,
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update { it.copy(isUploading = false, uploadError = t.message) }
+                }
+        }
+    }
+
     fun onUploadSuccessShown() {
         _state.update { it.copy(uploadSuccess = false) }
     }
@@ -119,9 +151,17 @@ class EvidenceGalleryViewModel(
         private val repository: EvidenceRepository,
         private val taskId: Int,
         private val isTaskCompleted: Boolean = false,
+        private val healthConnectManager: HealthConnectManager,
+        private val evidenceType: String? = null,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T =
-            EvidenceGalleryViewModel(repository, taskId, isTaskCompleted) as T
+            EvidenceGalleryViewModel(
+                repository,
+                taskId,
+                isTaskCompleted,
+                healthConnectManager,
+                evidenceType,
+            ) as T
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -70,14 +70,15 @@ object Routes {
     const val HABIT_DETAIL = "habit_detail/{habitId}"
     const val CREATE_HABIT_TASK = "create_habit_task?habitId={habitId}"
     const val HABIT_TASK_DETAIL = "habit_task_detail/{taskId}"
-    const val TASK_EVIDENCES = "task_evidences/{taskId}?isCompleted={isCompleted}"
+    const val TASK_EVIDENCES = "task_evidences/{taskId}?isCompleted={isCompleted}&evidence={evidence}"
     const val EDIT_HABIT_TASK = "edit_habit_task/{taskId}"
     const val COACH = "coach"
 
     fun habitDetail(id: Int) = "habit_detail/$id"
     fun createHabitTask(habitId: Int = -1) = "create_habit_task?habitId=$habitId"
     fun habitTaskDetail(taskId: Int) = "habit_task_detail/$taskId"
-    fun taskEvidences(taskId: Int, isCompleted: Boolean = false) = "task_evidences/$taskId?isCompleted=$isCompleted"
+    fun taskEvidences(taskId: Int, isCompleted: Boolean = false, evidence: String = "") =
+        "task_evidences/$taskId?isCompleted=$isCompleted&evidence=$evidence"
     fun editHabitTask(taskId: Int) = "edit_habit_task/$taskId"
 
     const val ARG_REFRESH_HABITS = "refresh_habits"
@@ -487,8 +488,10 @@ fun AppNavigation(
                 onBack = { navController.popBackStack() },
                 onDone = { navController.popBackStack(Routes.DASHBOARD, inclusive = false) },
                 onViewEvidences = {
-                    val isCompleted = vm.state.value.task?.isCompleted ?: false
-                    navController.navigate(Routes.taskEvidences(taskId, isCompleted))
+                    val task = vm.state.value.task
+                    navController.navigate(
+                        Routes.taskEvidences(taskId, task?.isCompleted ?: false, task?.evidence ?: ""),
+                    )
                 },
                 onEdit = { loadedTask ->
                     navController.navigate(Routes.editHabitTask(loadedTask.id))
@@ -515,12 +518,20 @@ fun AppNavigation(
             arguments = listOf(
                 navArgument("taskId") { type = NavType.IntType },
                 navArgument("isCompleted") { type = NavType.BoolType; defaultValue = false },
+                navArgument("evidence") { type = NavType.StringType; defaultValue = "" },
             ),
         ) { backStackEntry ->
             val taskId = backStackEntry.arguments?.getInt("taskId") ?: return@composable
             val isCompleted = backStackEntry.arguments?.getBoolean("isCompleted") ?: false
+            val evidence = backStackEntry.arguments?.getString("evidence").orEmpty()
             val vm: EvidenceGalleryViewModel = viewModel(
-                factory = EvidenceGalleryViewModel.Factory(container.evidenceRepository, taskId, isCompleted),
+                factory = EvidenceGalleryViewModel.Factory(
+                    container.evidenceRepository,
+                    taskId,
+                    isCompleted,
+                    container.healthConnectManager,
+                    evidence,
+                ),
             )
             EvidenceGalleryScreen(
                 viewModel = vm,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,6 +322,23 @@
     <string name="home_delete_habit_confirm">Eliminar</string>
     <string name="home_delete_habit_cancel">Cancelar</string>
 
+    <!-- Evidencia: Health Connect -->
+    <string name="evidence_health_sync_button">Sincronizar Health Connect</string>
+    <string name="evidence_health_pick_title">¿Qué dato quieres registrar?</string>
+    <string name="evidence_health_metric_steps">Pasos de hoy</string>
+    <string name="evidence_health_metric_distance">Distancia de hoy (km)</string>
+    <string name="evidence_health_metric_calories">Calorías activas de hoy</string>
+    <string name="evidence_health_metric_exercise">Minutos de ejercicio de hoy</string>
+    <string name="evidence_health_cancel">Cancelar</string>
+    <string name="evidence_health_unavailable">Health Connect no está disponible en este dispositivo.</string>
+    <string name="evidence_health_permission_denied">Se necesitan permisos de Health Connect para leer tus datos.</string>
+    <string name="evidence_health_read_failed">No se pudieron leer los datos de Health Connect.</string>
+    <string name="evidence_health_value_steps">%1$s pasos</string>
+    <string name="evidence_health_value_distance">%1$s km recorridos</string>
+    <string name="evidence_health_value_calories">%1$s kcal activas</string>
+    <string name="evidence_health_value_exercise">%1$s min de ejercicio</string>
+    <string name="evidence_health_value_generic">%1$s %2$s</string>
+
     <!-- Notificaciones de tareas -->
     <string name="notif_channel_task_reminders">Recordatorios de tareas</string>
     <string name="notif_task_pending_today_title">Tienes una tarea pendiente para hoy</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ mockwebserver = "4.12.0"
 archCoreTesting = "2.2.0"
 coil = "2.7.0"
 workManager = "2.9.1"
+healthConnect = "1.1.0-alpha07"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,6 +55,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
+androidx-health-connect-client = { group = "androidx.health.connect", name = "connect-client", version.ref = "healthConnect" }
 
 # Networking
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }


### PR DESCRIPTION
## 📖 Description

  Integrates **Health Connect** so tasks whose completion criteria is **evidence**
  with type **HEALTH_CONNECT** can be completed using real health data read from
  the device.

  In the evidences screen, the **"+" button now adapts to the task's evidence
  type**:
  - **PHOTO** → opens the image picker.
  - **VIDEO** → opens the video picker.
  - **HEALTH_CONNECT** → asks which metric to read (steps, distance, active
    calories or exercise minutes), reads today's total from Health Connect, and
    attaches it as the evidence's `healthDataJson`.

  Once the reading is attached, the task can be completed (the backend only
  requires that at least one evidence exists). Health evidence is shown with a
  readable label (e.g. "0 pasos") instead of raw JSON.
  
  **No backend changes** — the API already accepts `healthDataJson`.

  ---

  ## 🎯 Purpose

  `HEALTH_CONNECT` was only a stored label: the app had no Health Connect code, so
  those tasks could only be completed by attaching a photo. This makes the
  criterion real by reading the user's health data and registering it as evidence,
  which is what marks the task as completed.

  ---

  ## 🔄 Type of Change

  - [x] ✨ New feature
  - [x] 🐛 Bug fix
  - [ ] ♻️ Refactor
  - [ ] 📝 Documentation update
  - [ ] ⚡ Performance improvement
  - [ ] 🔧 Other (please describe):
  
  ---

  ## 🧪 How Has This Been Tested?

  - [x] Manual testing
  - [ ] Unit tests
  - [ ] Integration tests

  Testing process:

  - `:app:compileDebugKotlin` builds successfully.
  - Manual end-to-end on a physical Android 14 device with Health Connect:
    - On a HEALTH_CONNECT task, "+" prompts for the metric and then the Health
      Connect permission screen (after adding the Android 14 permission-usage
    - The selected metric's daily total is read, posted as evidence and shown as
      a readable value (e.g. "0 pasos") with a health icon.
    - PHOTO/VIDEO tasks still open the gallery picker from the same "+" button.
    - With evidence present, the task completes successfully.
 
  ---

  ## 📸 Screenshots (if applicable)

<img width="405" height="838" alt="image" src="https://github.com/user-attachments/assets/c75f5b86-37ec-4edf-92cc-917917ac8a07" />
<img width="407" height="828" alt="image" src="https://github.com/user-attachments/assets/cad0739d-ecd8-4ed8-8ee8-b3b02446d61d" />
<img width="393" height="837" alt="image" src="https://github.com/user-attachments/assets/37c7c268-5c2b-4caa-9450-53b25f08c022" />


  ---

  ## 🚀 Deployment Notes (if needed)
  
  - Adds the `androidx.health.connect:connect-client` dependency and overrides its
    minSdk (library is minSdk 26, app is 24); Health Connect features are guarded
    by an availability check at runtime.
  - Adds the health read permissions (`READ_STEPS`, `READ_DISTANCE`,
    `READ_ACTIVE_CALORIES_BURNED`, `READ_EXERCISE`), the `SHOW_PERMISSIONS_RATIONALE`
    intent-filter and the Android 14+ `VIEW_PERMISSION_USAGE` / `HEALTH_PERMISSIONS`
    activity-alias required to request health permissions.
  - Requires Health Connect to be available on the device; metrics are read for the
    current day and the task model is unchanged (no metric/target stored per task).

  ---

  ## ✅ Checklist
  
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  - [ ] I have updated documentation if necessary
  - [x] My changes do not introduce new warnings or errors