### PR TITLE
Fix item view

### DIFF
--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -22,6 +22,7 @@ import com.example.leveluplife.R
 import com.example.leveluplife.data.auth.SessionEvent
 import com.example.leveluplife.data.habits.HabitRepository
 import com.example.leveluplife.data.network.dto.HabitTaskDto
+import com.example.leveluplife.data.network.dto.RewardItemDto
 import com.example.leveluplife.notifications.TaskReminderScheduler
 import com.example.leveluplife.ui.auth.LoginScreen
 import com.example.leveluplife.ui.auth.LoginViewModel
@@ -37,6 +38,8 @@ import com.example.leveluplife.ui.coach.CoachScreen
 import com.example.leveluplife.ui.coach.CoachViewModel
 import com.example.leveluplife.ui.inventory.InventoryScreen
 import com.example.leveluplife.ui.inventory.InventoryViewModel
+import com.example.leveluplife.ui.store.StoreDetailScreen
+import com.example.leveluplife.ui.store.StoreDetailViewModel
 import com.example.leveluplife.ui.store.StoreScreen
 import com.example.leveluplife.ui.store.StoreViewModel
 import com.example.leveluplife.ui.evidence.EvidenceGalleryScreen
@@ -544,6 +547,14 @@ fun AppNavigation(
                 onOpenInventory = {
                     navController.navigate(Routes.INVENTORY) { launchSingleTop = true }
                 },
+                onItemClick = { item ->
+                    val itemJson = json.encodeToString(RewardItemDto.serializer(), item)
+                    navController.navigate(Routes.STORE_DETAIL)
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        Routes.ARG_STORE_ITEM_JSON,
+                        itemJson,
+                    )
+                },
                 onPurchaseSuccess = {
                     runCatching {
                         navController.getBackStackEntry(Routes.DASHBOARD)
@@ -551,6 +562,23 @@ fun AppNavigation(
                             .set(Routes.ARG_REFRESH_PLAYER, true)
                     }
                 },
+            )
+        }
+        composable(Routes.STORE_DETAIL) { backStackEntry ->
+            val itemJson = backStackEntry.savedStateHandle.get<String>(Routes.ARG_STORE_ITEM_JSON)
+                ?: navController.previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.get<String>(Routes.ARG_STORE_ITEM_JSON)
+            val item = itemJson?.let {
+                runCatching { json.decodeFromString(RewardItemDto.serializer(), it) }.getOrNull()
+            } ?: return@composable
+            val vm: StoreDetailViewModel = viewModel(
+                factory = StoreDetailViewModel.Factory(container.rewardRepository),
+            )
+            StoreDetailScreen(
+                item = item,
+                viewModel = vm,
+                onBack = { navController.popBackStack() },
             )
         }
         composable(Routes.INVENTORY) {

--- a/app/src/main/java/com/example/leveluplife/ui/store/StoreDetailScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/store/StoreDetailScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -50,6 +49,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.Image
+import androidx.compose.ui.res.painterResource
 import coil.compose.AsyncImage
 import com.example.leveluplife.R
 import com.example.leveluplife.data.network.dto.RewardItemDto
@@ -107,7 +108,7 @@ fun StoreDetailScreen(
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState()),
         ) {
-            ItemHeroImage(imageUrl = item.imageUrl, name = item.name)
+            ItemHeroImage(itemId = item.id, typeId = item.typeId, imageUrl = item.imageUrl, name = item.name)
 
             Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
                 Text(
@@ -270,28 +271,32 @@ fun StoreDetailScreen(
 }
 
 @Composable
-private fun ItemHeroImage(imageUrl: String?, name: String) {
-    if (!imageUrl.isNullOrBlank()) {
-        AsyncImage(
+private fun ItemHeroImage(itemId: Int, typeId: Int?, imageUrl: String?, name: String) {
+    val heroMod = Modifier
+        .fillMaxWidth()
+        .height(220.dp)
+        .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
+
+    val localDrawable = drawableForItemId(itemId)
+    when {
+        localDrawable != null -> Image(
+            painter = painterResource(localDrawable),
+            contentDescription = name,
+            contentScale = ContentScale.Crop,
+            modifier = heroMod,
+        )
+        !imageUrl.isNullOrBlank() -> AsyncImage(
             model = imageUrl,
             contentDescription = name,
             contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(16f / 9f)
-                .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp)),
+            modifier = heroMod,
         )
-    } else {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(16f / 9f)
-                .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
-                .background(MaterialTheme.colorScheme.primaryContainer),
+        else -> Box(
+            modifier = heroMod.background(MaterialTheme.colorScheme.primaryContainer),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
-                imageVector = Icons.Filled.ShoppingBag,
+                imageVector = iconForTypeId(typeId),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(64.dp),

--- a/app/src/main/java/com/example/leveluplife/ui/store/StoreScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/store/StoreScreen.kt
@@ -75,6 +75,7 @@ fun StoreScreen(
     viewModel: StoreViewModel,
     onBack: () -> Unit,
     onOpenInventory: () -> Unit,
+    onItemClick: (RewardItemDto) -> Unit = {},
     onPurchaseSuccess: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -204,6 +205,7 @@ fun StoreScreen(
                             isBuying = item.id == state.buyingItemId,
                             anyBuying = state.buyingItemId != null,
                             onBuy = { viewModel.purchase(item) },
+                            onClick = { onItemClick(item) },
                         )
                     }
                 }
@@ -241,15 +243,18 @@ private fun SectionHeader(typeName: String, typeId: Int?) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RewardItemCard(
     item: RewardItemDto,
     isBuying: Boolean,
     anyBuying: Boolean,
     onBuy: () -> Unit,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
+        onClick = onClick,
         shape = RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
         modifier = modifier.fillMaxWidth(),


### PR DESCRIPTION
# 📌 Pull Request 

  📖 Description

  Enabled navigation to item detail in the item store. Tapping any card in the list navigates the user to a detail screen showing the image, name, type, gold cost, effect value, full description, and a purchase button. Additionally fixed image loading in the detail screen and reduced the hero image size for a better visual experience.
  
  ---
  🎯 Purpose

  Previously, store cards were not interactive: users could only see a truncated name, a clipped description, and a buy button. There was no way to view an item's full information. This PR connects the already-existing StoreDetailScreen that was neither registered in the navigation graph nor reachable from the list.

  ---
  🔄 Type of Change

  - [x] 🐛 Bug fix
  - [x] ✨  New feature

  ---
  🧪 How Has This Been Tested?

  - [x] Manual testing

  Process:
  1. Open the store from the dashboard.
  2. Tap an item card → navigates correctly to the detail screen.
  3. Verified that the local drawable for each item renders correctly (previously the screen attempted to load from imageUrl, which is null, always showing the placeholder).
  4. Verified that the purchase button in the detail screen works correctly and displays loading and success states.
  5. Clean build with no warnings or errors.

  ---
  📸 Screenshots (if applicable)

N/A

  ---
  🚀 Deployment Notes (if needed)

  None. No backend, database, or dependency changes.

  ---
  ✅  Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  - [x] My changes do not introduce new warnings or errors

  ---
  🧩 Related Issues

N/A

  ---