### PR TITLE
functions ready

### DIFF
--- a/app/src/main/java/com/example/leveluplife/data/network/RewardApi.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/RewardApi.kt
@@ -1,19 +1,24 @@
 package com.example.leveluplife.data.network
 
-import com.example.leveluplife.data.network.dto.PlayerInventoryDto
+import com.example.leveluplife.data.network.dto.ActivateItemResponseDto
+import com.example.leveluplife.data.network.dto.PurchaseResponseDto
 import com.example.leveluplife.data.network.dto.RewardItemDto
+import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface RewardApi {
-    @GET("api/rewarditem")
+    @GET("api/RewardItem")
     suspend fun listRewardItems(): Response<List<RewardItemDto>>
 
-    @POST("api/rewarditem/{itemId}/purchase")
-    suspend fun purchaseItem(@Path("itemId") itemId: Int): Response<PlayerInventoryDto>
+    @POST("api/RewardItem/{itemId}/purchase")
+    suspend fun purchaseItem(@Path("itemId") itemId: Int): Response<PurchaseResponseDto>
 
-    @GET("api/rewarditem/inventory")
-    suspend fun getInventory(): Response<List<PlayerInventoryDto>>
+    @GET("api/RewardItem/inventory")
+    suspend fun getInventoryRaw(): Response<ResponseBody>
+
+    @POST("api/RewardItem/inventory/{inventoryId}/activate")
+    suspend fun activateItem(@Path("inventoryId") inventoryId: Int): Response<ActivateItemResponseDto>
 }

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/PlayerProfileDtos.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/PlayerProfileDtos.kt
@@ -13,6 +13,7 @@ data class GetPlayerProfileResponseDto(
     val experiencePointsRequiredForNextLevel: Int = 0,
     val levelProgressPercent: Double = 0.0,
     val daysStreak: Int = 0,
+    val gold: Int = 0,
     @SerialName("statusIsActive") val statusIsActive: Boolean = true,
     @SerialName("PlayerUserLastLogin") val playerUserLastLogin: String? = null,
     @SerialName("bio") val bio: String? = null,

--- a/app/src/main/java/com/example/leveluplife/data/network/dto/RewardItemDto.kt
+++ b/app/src/main/java/com/example/leveluplife/data/network/dto/RewardItemDto.kt
@@ -1,6 +1,7 @@
 package com.example.leveluplife.data.network.dto
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 @Serializable
 data class RewardItemDto(
@@ -11,6 +12,7 @@ data class RewardItemDto(
     val description: String? = null,
     val costGold: Double = 0.0,
     val effectValue: Double? = null,
+    val durationDays: Int? = null,
     val imageUrl: String? = null,
     val isActive: Boolean = true,
 )
@@ -25,7 +27,42 @@ data class PlayerInventoryDto(
     val rewardItemTypeName: String? = null,
     val costGold: Double = 0.0,
     val effectValue: Double? = null,
+    val durationDays: Int? = null,
     val quantity: Int = 1,
     val isEquipped: Boolean = false,
     val acquiredAt: String = "",
+)
+
+@Serializable
+data class ActiveEffectDto(
+    val id: Int = 0,
+    val inventoryId: Int = 0,
+    val rewardItemId: Int = 0,
+    val rewardItemName: String = "",
+    val rewardItemTypeId: Int? = null,
+    val rewardItemTypeName: String? = null,
+    val effectValue: Double? = null,
+    val remainingCharges: Int? = null,
+    val activatedAt: String = "",
+    val expiresAt: String? = null,
+    val isActive: Boolean = true,
+)
+
+@Serializable
+data class InventoryResponseDto(
+    @JsonNames("items", "Items") val items: List<PlayerInventoryDto> = emptyList(),
+    @JsonNames("activeEffects", "ActiveEffects") val activeEffects: List<ActiveEffectDto> = emptyList(),
+)
+
+@Serializable
+data class PurchaseResponseDto(
+    val inventory: PlayerInventoryDto,
+    val remainingGold: Int = 0,
+)
+
+@Serializable
+data class ActivateItemResponseDto(
+    val inventory: PlayerInventoryDto,
+    val activeEffect: ActiveEffectDto? = null,
+    val recoveryMessage: String? = null,
 )

--- a/app/src/main/java/com/example/leveluplife/data/player/PlayerProfile.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/PlayerProfile.kt
@@ -17,6 +17,7 @@ data class PlayerProfile(
     val experiencePointsRequiredForNextLevel: Int = 0,
     val levelProgressPercent: Double = 0.0,
     val daysStreak: Int = 0,
+    val gold: Int = 0,
 ) {
     val levelProgressFraction: Float
         get() = levelProgressPercent.coerceIn(0.0, 1.0).toFloat()

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileCache.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileCache.kt
@@ -31,6 +31,8 @@ interface ProfileCache {
         levelProgressPercent: Double,
         daysStreak: Int? = null,
     )
+    suspend fun addGoldEarned(amount: Int)
+    suspend fun setGold(gold: Int)
     /** Clears in-memory state only; per-user disk cache is kept for the same account on re-login. */
     fun clearMemory()
     /** Wipes all persisted profile entries (tests / account reset). */
@@ -99,6 +101,18 @@ class DefaultProfileCache(
         )
     }
 
+    override suspend fun addGoldEarned(amount: Int) {
+        if (amount <= 0) return
+        val current = _profile.value ?: return
+        update(current.copy(gold = current.gold + amount))
+    }
+
+    override suspend fun setGold(gold: Int) {
+        val current = _profile.value ?: return
+        if (current.gold == gold) return
+        update(current.copy(gold = gold))
+    }
+
     override fun clearMemory() {
         etag = null
         _profile.value = null
@@ -138,6 +152,7 @@ class DefaultProfileCache(
                 experiencePointsRequiredForNextLevel = prefs[scopedKey(userId, Suffix.XP_REQUIRED)]?.toIntOrNull() ?: 0,
                 levelProgressPercent = prefs[scopedKey(userId, Suffix.LEVEL_PROGRESS)]?.toDoubleOrNull() ?: 0.0,
                 daysStreak = prefs[scopedKey(userId, Suffix.DAYS_STREAK)]?.toIntOrNull() ?: 0,
+                gold = prefs[scopedKey(userId, Suffix.GOLD)]?.toIntOrNull() ?: 0,
             ),
             etag = prefs[scopedKey(userId, Suffix.ETAG)],
         )
@@ -167,6 +182,7 @@ class DefaultProfileCache(
         prefs[scopedKey(userId, Suffix.XP_REQUIRED)] = profile.experiencePointsRequiredForNextLevel.toString()
         prefs[scopedKey(userId, Suffix.LEVEL_PROGRESS)] = profile.levelProgressPercent.toString()
         prefs[scopedKey(userId, Suffix.DAYS_STREAK)] = profile.daysStreak.toString()
+        prefs[scopedKey(userId, Suffix.GOLD)] = profile.gold.toString()
         etag?.let { prefs[scopedKey(userId, Suffix.ETAG)] = it }
     }
 
@@ -226,6 +242,7 @@ class DefaultProfileCache(
         const val XP_REQUIRED = "xp_required"
         const val LEVEL_PROGRESS = "level_progress"
         const val DAYS_STREAK = "days_streak"
+        const val GOLD = "gold"
     }
 
     private companion object {

--- a/app/src/main/java/com/example/leveluplife/data/player/ProfileRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/player/ProfileRepository.kt
@@ -166,6 +166,7 @@ private fun GetPlayerProfileResponseDto.toDomain(apiBaseUrl: String): PlayerProf
     experiencePointsRequiredForNextLevel = experiencePointsRequiredForNextLevel,
     levelProgressPercent = levelProgressPercent,
     daysStreak = daysStreak,
+    gold = gold,
 )
 
 private fun PlayerProfileDto.toDomain(apiBaseUrl: String): PlayerProfile = PlayerProfile(

--- a/app/src/main/java/com/example/leveluplife/data/rewards/RewardRepository.kt
+++ b/app/src/main/java/com/example/leveluplife/data/rewards/RewardRepository.kt
@@ -1,16 +1,27 @@
 package com.example.leveluplife.data.rewards
 
+import com.example.leveluplife.data.network.NetworkModule
 import com.example.leveluplife.data.network.RewardApi
+import com.example.leveluplife.data.network.dto.ActivateItemResponseDto
+import com.example.leveluplife.data.network.dto.ApiErrorEnvelopeDto
+import com.example.leveluplife.data.network.dto.InventoryResponseDto
 import com.example.leveluplife.data.network.dto.PlayerInventoryDto
+import com.example.leveluplife.data.network.dto.PurchaseResponseDto
 import com.example.leveluplife.data.network.dto.RewardItemDto
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 
 interface RewardRepository {
     suspend fun getRewardItems(): Result<List<RewardItemDto>>
-    suspend fun purchaseItem(itemId: Int): Result<PlayerInventoryDto>
-    suspend fun getInventory(): Result<List<PlayerInventoryDto>>
+    suspend fun purchaseItem(itemId: Int): Result<PurchaseResponseDto>
+    suspend fun getInventory(): Result<InventoryResponseDto>
+    suspend fun activateItem(inventoryId: Int): Result<ActivateItemResponseDto>
 }
 
 class DefaultRewardRepository(private val api: RewardApi) : RewardRepository {
+
+    private val json = NetworkModule.jsonParser()
 
     override suspend fun getRewardItems(): Result<List<RewardItemDto>> = try {
         val response = api.listRewardItems()
@@ -23,25 +34,96 @@ class DefaultRewardRepository(private val api: RewardApi) : RewardRepository {
         Result.failure(t)
     }
 
-    override suspend fun purchaseItem(itemId: Int): Result<PlayerInventoryDto> = try {
+    override suspend fun purchaseItem(itemId: Int): Result<PurchaseResponseDto> = try {
         val response = api.purchaseItem(itemId)
         when {
             response.isSuccessful -> Result.success(requireNotNull(response.body()))
-            response.code() == 402 -> Result.failure(Exception("insufficient_funds"))
+            response.code() == 400 -> Result.failure(Exception(mapPurchaseError(response)))
             else -> Result.failure(Exception("HTTP ${response.code()}"))
         }
     } catch (t: Throwable) {
         Result.failure(t)
     }
 
-    override suspend fun getInventory(): Result<List<PlayerInventoryDto>> = try {
-        val response = api.getInventory()
+    override suspend fun getInventory(): Result<InventoryResponseDto> = try {
+        val response = api.getInventoryRaw()
         when {
-            response.isSuccessful -> Result.success(response.body() ?: emptyList())
+            response.isSuccessful -> {
+                val raw = response.body()?.string().orEmpty()
+                Result.success(parseInventoryResponse(raw))
+            }
             response.code() == 401 -> Result.failure(Exception("unauthorized"))
             else -> Result.failure(Exception("HTTP ${response.code()}"))
         }
     } catch (t: Throwable) {
         Result.failure(t)
+    }
+
+    override suspend fun activateItem(inventoryId: Int): Result<ActivateItemResponseDto> = try {
+        val response = api.activateItem(inventoryId)
+        when {
+            response.isSuccessful -> Result.success(requireNotNull(response.body()))
+            response.code() == 400 -> Result.failure(Exception(mapActivateError(response)))
+            else -> Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (t: Throwable) {
+        Result.failure(t)
+    }
+
+    private fun parseInventoryResponse(rawBody: String): InventoryResponseDto {
+        if (rawBody.isBlank()) return InventoryResponseDto()
+        val element = json.parseToJsonElement(rawBody)
+        return when (element) {
+            is JsonArray -> InventoryResponseDto(
+                items = json.decodeFromJsonElement<List<PlayerInventoryDto>>(element),
+            )
+            is JsonObject -> {
+                val itemsNode = element["items"] ?: element["Items"]
+                val effectsNode = element["activeEffects"] ?: element["ActiveEffects"]
+                InventoryResponseDto(
+                    items = itemsNode?.let { json.decodeFromJsonElement(it) } ?: emptyList(),
+                    activeEffects = effectsNode?.let { json.decodeFromJsonElement(it) } ?: emptyList(),
+                )
+            }
+            else -> InventoryResponseDto()
+        }
+    }
+
+    private fun mapPurchaseError(response: retrofit2.Response<*>): String {
+        val envelope = parseErrorEnvelope(response)
+        val message = envelope?.message.orEmpty().lowercase()
+        val details = envelope?.details.orEmpty().lowercase()
+        return when {
+            message.contains("insufficient") || details.contains("insufficient") ||
+                message.contains("gold") && details.contains("only have") ->
+                "insufficient_gold"
+            else -> "generic"
+        }
+    }
+
+    private fun mapActivateError(response: retrofit2.Response<*>): String {
+        val envelope = parseErrorEnvelope(response)
+        val combined = "${envelope?.message.orEmpty()} ${envelope?.details.orEmpty()}".lowercase()
+        return when {
+            combined.contains("quantity") || combined.contains("no units") ||
+                combined.contains("sin unidades") ->
+                "no_quantity"
+            combined.contains("already active") || combined.contains("ya activo") ||
+                combined.contains("effect already") ->
+                "effect_already_active"
+            combined.contains("recovery") || combined.contains("streak") ||
+                combined.contains("recuper") || combined.contains("objetivo") ||
+                combined.contains("no target") ->
+                "recovery_no_target"
+            else -> "generic"
+        }
+    }
+
+    private fun parseErrorEnvelope(response: retrofit2.Response<*>): ApiErrorEnvelopeDto? {
+        val errorBody = response.errorBody()?.string().orEmpty()
+        if (errorBody.isBlank()) return null
+        return runCatching {
+            json.decodeFromString<ApiErrorEnvelopeDto>(errorBody)
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModel.kt
@@ -91,6 +91,7 @@ class HabitTaskDetailViewModel(
                         levelProgressPercent = response.levelProgressPercent,
                         daysStreak = response.daysStreak,
                     )
+                    profileCache.addGoldEarned(response.xpEarned)
                     _state.update {
                         it.copy(
                             isCompleting = false,

--- a/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/TaskCompletionRewardDialog.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/habittaskdetail/TaskCompletionRewardDialog.kt
@@ -162,6 +162,13 @@ fun TaskCompletionRewardDialog(
                     color = GoldAccent,
                 )
 
+                Text(
+                    text = stringResource(R.string.task_reward_gold_earned, reward.xpEarned),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = GoldAccent.copy(alpha = 0.85f),
+                )
+
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Backpack
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Delete
@@ -87,6 +88,7 @@ import com.example.leveluplife.data.network.dto.HabitDto
 import com.example.leveluplife.data.player.PlayerProfile
 import com.example.leveluplife.data.player.ProfileCache
 import com.example.leveluplife.ui.components.LulConfirmAlertDialog
+import com.example.leveluplife.ui.rewards.GoldColor
 import java.util.Calendar
 
 private val StreakInactive = Color(0xFF6B7280)
@@ -107,6 +109,7 @@ fun HomeScreen(
     onCreateHabit: () -> Unit = {},
     onOpenCoach: () -> Unit = {},
     onOpenStore: () -> Unit = {},
+    onOpenBackpack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
@@ -175,6 +178,7 @@ fun HomeScreen(
                     onOpenProfile = onOpenProfile,
                     displayName = cachedProfile?.userName,
                     onOpenCategories = onOpenCategories,
+                    onOpenBackpack = onOpenBackpack,
                 )
                 Spacer(Modifier.height(12.dp))
                 PlayerLevelCard(profile = cachedProfile)
@@ -289,6 +293,7 @@ private fun HomeHeader(
     onOpenProfile: () -> Unit,
     displayName: String?,
     onOpenCategories: () -> Unit,
+    onOpenBackpack: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -331,6 +336,14 @@ private fun HomeHeader(
                     .size(46.dp),
             ) {
                 Icon(Icons.Filled.Category, contentDescription = "Categorías", tint = MaterialTheme.colorScheme.onBackground)
+            }
+            IconButton(
+                onClick = onOpenBackpack,
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(14.dp))
+                    .size(46.dp),
+            ) {
+                Icon(Icons.Filled.Backpack, contentDescription = stringResource(R.string.backpack_open_cd), tint = MaterialTheme.colorScheme.onBackground)
             }
             IconButton(
                 onClick = onOpenProfile,
@@ -396,6 +409,7 @@ private fun PlayerLevelCard(profile: PlayerProfile?) {
 private fun EngagementStatsRow(profile: PlayerProfile?) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         StreakChip(daysStreak = profile?.daysStreak ?: 0)
+        GoldChip(gold = profile?.gold ?: 0)
         TotalXpChip(totalXp = profile?.totalExperiencePoints ?: 0)
     }
 }
@@ -450,6 +464,30 @@ private fun StreakChip(daysStreak: Int) {
             } else {
                 MaterialTheme.colorScheme.onSurfaceVariant
             },
+            fontWeight = FontWeight.Bold,
+            fontSize = 13.sp,
+        )
+    }
+}
+
+@Composable
+private fun GoldChip(gold: Int) {
+    Row(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(50.dp))
+            .padding(horizontal = 14.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Star,
+            contentDescription = stringResource(R.string.home_gold_content_description, gold),
+            tint = GoldColor,
+            modifier = Modifier.size(18.dp),
+        )
+        Text(
+            text = stringResource(R.string.home_gold_chip, gold),
+            color = MaterialTheme.colorScheme.onBackground,
             fontWeight = FontWeight.Bold,
             fontSize = 13.sp,
         )

--- a/app/src/main/java/com/example/leveluplife/ui/inventory/InventoryScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/inventory/InventoryScreen.kt
@@ -1,5 +1,6 @@
 package com.example.leveluplife.ui.inventory
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,38 +20,49 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.Healing
-import androidx.compose.material.icons.filled.Inventory2
-import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Backpack
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.leveluplife.R
+import com.example.leveluplife.data.network.dto.ActiveEffectDto
 import com.example.leveluplife.data.network.dto.PlayerInventoryDto
-import com.example.leveluplife.ui.store.GoldColor
+import com.example.leveluplife.ui.rewards.GoldColor
+import com.example.leveluplife.ui.rewards.drawableForItemId
+import com.example.leveluplife.ui.rewards.iconForTypeId
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,10 +72,35 @@ fun InventoryScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val errorNoQuantity = stringResource(R.string.backpack_activate_error_no_quantity)
+    val errorAlreadyActive = stringResource(R.string.backpack_activate_error_already_active)
+    val errorRecovery = stringResource(R.string.backpack_activate_error_recovery)
+    val errorGeneric = stringResource(R.string.backpack_activate_error_generic)
+
+    LaunchedEffect(state.activateError) {
+        val key = state.activateError ?: return@LaunchedEffect
+        val msg = when (key) {
+            "no_quantity" -> errorNoQuantity
+            "effect_already_active" -> errorAlreadyActive
+            "recovery_no_target" -> errorRecovery
+            else -> errorGeneric
+        }
+        snackbarHostState.showSnackbar(msg)
+        viewModel.clearActivateError()
+    }
+
+    LaunchedEffect(state.recoveryMessage) {
+        val message = state.recoveryMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        viewModel.clearRecoveryMessage()
+    }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.background,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {
@@ -109,13 +146,13 @@ fun InventoryScreen(
                 }
             }
 
-            state.items.isEmpty() -> Box(
+            state.items.isEmpty() && state.activeEffects.isEmpty() -> Box(
                 modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center,
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(24.dp)) {
                     Icon(
-                        imageVector = Icons.Filled.Inventory2,
+                        imageVector = Icons.Filled.Backpack,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
                         modifier = Modifier.size(64.dp),
@@ -138,8 +175,34 @@ fun InventoryScreen(
                 ),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                items(state.items, key = { it.id }) { inventoryItem ->
-                    InventoryItemCard(item = inventoryItem)
+                if (state.activeEffects.isNotEmpty()) {
+                    item(key = "effects_header") {
+                        SectionLabel(text = stringResource(R.string.backpack_effects_title))
+                    }
+                    items(state.activeEffects, key = { "effect_${it.id}" }) { effect ->
+                        ActiveEffectCard(effect = effect)
+                    }
+                    item(key = "effects_spacer") {
+                        Spacer(Modifier.height(8.dp))
+                    }
+                }
+
+                if (state.items.isNotEmpty()) {
+                    item(key = "items_header") {
+                        SectionLabel(text = stringResource(R.string.backpack_items_title))
+                    }
+                    items(state.items, key = { "inv_${it.id}" }) { inventoryItem ->
+                        val hasActiveEffect = state.activeEffects.any {
+                            it.inventoryId == inventoryItem.id && it.isActive
+                        }
+                        InventoryItemCard(
+                            item = inventoryItem,
+                            canActivate = inventoryItem.quantity > 0 && !hasActiveEffect,
+                            isActivating = inventoryItem.id == state.activatingItemId,
+                            anyActivating = state.activatingItemId != null,
+                            onActivate = { viewModel.activate(inventoryItem.id) },
+                        )
+                    }
                 }
             }
         }
@@ -147,7 +210,102 @@ fun InventoryScreen(
 }
 
 @Composable
-private fun InventoryItemCard(item: PlayerInventoryDto, modifier: Modifier = Modifier) {
+private fun SectionLabel(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+            letterSpacing = 1.sp,
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
+        )
+    }
+}
+
+@Composable
+private fun ActiveEffectCard(effect: ActiveEffectDto, modifier: Modifier = Modifier) {
+    Card(
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f),
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.2f), RoundedCornerShape(10.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = iconForTypeId(effect.rewardItemTypeId),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = effect.rewardItemName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                effect.effectValue?.let { value ->
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = stringResource(R.string.backpack_effect_multiplier, formatEffectValue(value)),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+                effect.remainingCharges?.let { charges ->
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = stringResource(R.string.backpack_effect_charges, charges),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                effect.expiresAt?.let { expires ->
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = stringResource(R.string.backpack_effect_expires, formatExpiresAt(expires)),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InventoryItemCard(
+    item: PlayerInventoryDto,
+    canActivate: Boolean,
+    isActivating: Boolean,
+    anyActivating: Boolean,
+    onActivate: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Card(
         shape = RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
@@ -157,19 +315,7 @@ private fun InventoryItemCard(item: PlayerInventoryDto, modifier: Modifier = Mod
             modifier = Modifier.padding(14.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Box(
-                modifier = Modifier
-                    .size(52.dp)
-                    .background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(12.dp)),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = iconForTypeId(item.rewardItemTypeId),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(28.dp),
-                )
-            }
+            ItemImage(itemId = item.rewardItemId, typeId = item.rewardItemTypeId, name = item.rewardItemName)
 
             Spacer(Modifier.width(14.dp))
 
@@ -190,45 +336,114 @@ private fun InventoryItemCard(item: PlayerInventoryDto, modifier: Modifier = Mod
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                Spacer(Modifier.height(4.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Filled.Star,
-                        contentDescription = null,
-                        tint = GoldColor,
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(Modifier.width(2.dp))
+                item.effectValue?.let { value ->
+                    Spacer(Modifier.height(2.dp))
                     Text(
-                        text = stringResource(R.string.store_cost_gold, item.costGold.toInt()),
+                        text = stringResource(R.string.backpack_effect_multiplier, formatEffectValue(value)),
                         style = MaterialTheme.typography.bodySmall,
-                        color = GoldColor,
-                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (item.isEquipped && item.quantity == 0) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(R.string.backpack_equipped_badge),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
 
-            Box(
-                modifier = Modifier
-                    .size(36.dp)
-                    .background(MaterialTheme.colorScheme.primary, CircleShape),
-                contentAlignment = Alignment.Center,
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                Text(
-                    text = stringResource(R.string.inventory_quantity, item.quantity),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.Bold,
-                )
+                if (item.quantity > 0) {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .background(MaterialTheme.colorScheme.primary, CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.inventory_quantity, item.quantity),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+
+                if (canActivate) {
+                    Button(
+                        onClick = onActivate,
+                        enabled = !isActivating && !anyActivating,
+                        shape = RoundedCornerShape(8.dp),
+                        modifier = Modifier.height(32.dp),
+                        contentPadding = PaddingValues(horizontal = 10.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            disabledContainerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f),
+                        ),
+                    ) {
+                        if (isActivating) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            Text(
+                                text = stringResource(R.string.backpack_activate),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                    }
+                }
             }
         }
     }
 }
 
-private fun iconForTypeId(typeId: Int?): ImageVector = when (typeId) {
-    1 -> Icons.Filled.Shield
-    2 -> Icons.Filled.Bolt
-    3 -> Icons.Filled.AddCircle
-    4 -> Icons.Filled.Healing
-    else -> Icons.Filled.Star
+@Composable
+private fun ItemImage(itemId: Int, typeId: Int?, name: String) {
+    val drawableRes = drawableForItemId(itemId)
+    val sizeMod = Modifier
+        .size(52.dp)
+        .clip(RoundedCornerShape(12.dp))
+
+    if (drawableRes != null) {
+        Image(
+            painter = painterResource(drawableRes),
+            contentDescription = name,
+            contentScale = ContentScale.Crop,
+            modifier = sizeMod,
+        )
+    } else {
+        Box(
+            modifier = sizeMod.background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = iconForTypeId(typeId),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(28.dp),
+            )
+        }
+    }
 }
+
+private fun formatEffectValue(value: Double): String =
+    if (value == value.toLong().toDouble()) value.toLong().toString() else value.toString()
+
+private fun formatExpiresAt(expiresAt: String): String =
+    runCatching {
+        val instant = Instant.parse(expiresAt)
+        DateTimeFormatter.ofPattern("dd/MM HH:mm")
+            .withZone(ZoneId.systemDefault())
+            .format(instant)
+    }.getOrElse {
+        expiresAt.take(16).replace('T', ' ')
+    }

--- a/app/src/main/java/com/example/leveluplife/ui/inventory/InventoryUiState.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/inventory/InventoryUiState.kt
@@ -1,9 +1,14 @@
 package com.example.leveluplife.ui.inventory
 
+import com.example.leveluplife.data.network.dto.ActiveEffectDto
 import com.example.leveluplife.data.network.dto.PlayerInventoryDto
 
 data class InventoryUiState(
     val isLoading: Boolean = true,
     val items: List<PlayerInventoryDto> = emptyList(),
+    val activeEffects: List<ActiveEffectDto> = emptyList(),
+    val activatingItemId: Int? = null,
+    val activateError: String? = null,
+    val recoveryMessage: String? = null,
     val error: String? = null,
 )

--- a/app/src/main/java/com/example/leveluplife/ui/inventory/InventoryViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/inventory/InventoryViewModel.kt
@@ -23,14 +23,51 @@ class InventoryViewModel(
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null) }
             repository.getInventory()
-                .onSuccess { items ->
-                    _state.update { it.copy(isLoading = false, items = items) }
+                .onSuccess { response ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            items = response.items,
+                            activeEffects = response.activeEffects,
+                        )
+                    }
                 }
                 .onFailure { t ->
                     _state.update { it.copy(isLoading = false, error = t.message) }
                 }
         }
     }
+
+    fun activate(inventoryId: Int) {
+        if (_state.value.activatingItemId != null) return
+        viewModelScope.launch {
+            _state.update {
+                it.copy(activatingItemId = inventoryId, activateError = null, recoveryMessage = null)
+            }
+            repository.activateItem(inventoryId)
+                .onSuccess { response ->
+                    _state.update {
+                        it.copy(
+                            activatingItemId = null,
+                            recoveryMessage = response.recoveryMessage,
+                        )
+                    }
+                    load()
+                }
+                .onFailure { t ->
+                    val errorKey = when (t.message) {
+                        "no_quantity" -> "no_quantity"
+                        "effect_already_active" -> "effect_already_active"
+                        "recovery_no_target" -> "recovery_no_target"
+                        else -> "generic"
+                    }
+                    _state.update { it.copy(activatingItemId = null, activateError = errorKey) }
+                }
+        }
+    }
+
+    fun clearActivateError() = _state.update { it.copy(activateError = null) }
+    fun clearRecoveryMessage() = _state.update { it.copy(recoveryMessage = null) }
 
     class Factory(
         private val repository: RewardRepository,

--- a/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/navigation/AppNavigation.kt
@@ -301,6 +301,9 @@ fun AppNavigation(
                 onOpenStore = {
                     navController.navigate(Routes.STORE) { launchSingleTop = true }
                 },
+                onOpenBackpack = {
+                    navController.navigate(Routes.INVENTORY) { launchSingleTop = true }
+                },
             )
         }
         composable(Routes.PROFILE) {
@@ -536,10 +539,12 @@ fun AppNavigation(
         }
         composable(Routes.STORE) {
             val vm: StoreViewModel = viewModel(
-                factory = StoreViewModel.Factory(container.rewardRepository),
+                factory = StoreViewModel.Factory(container.rewardRepository, container.profileCache),
             )
+            val cachedProfile by container.profileCache.profile.collectAsState()
             StoreScreen(
                 viewModel = vm,
+                playerGold = cachedProfile?.gold ?: 0,
                 onBack = { navController.popBackStack() },
                 onOpenInventory = {
                     navController.navigate(Routes.INVENTORY) { launchSingleTop = true }

--- a/app/src/main/java/com/example/leveluplife/ui/rewards/RewardItemUi.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/rewards/RewardItemUi.kt
@@ -1,0 +1,37 @@
+package com.example.leveluplife.ui.rewards
+
+import androidx.annotation.DrawableRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Healing
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.leveluplife.R
+
+val GoldColor = Color(0xFFF59E0B)
+
+@DrawableRes
+fun drawableForItemId(id: Int): Int? = when (id) {
+    1 -> R.drawable.escudo_1
+    2 -> R.drawable.escudo_2
+    3 -> R.drawable.escudo_3
+    4 -> R.drawable.potenciacion_1
+    5 -> R.drawable.potenciacion_2
+    6 -> R.drawable.potenciacion_3
+    7 -> R.drawable.mejora_1
+    8 -> R.drawable.mejora_2
+    9 -> R.drawable.mejora_3
+    10 -> R.drawable.mejora_4
+    else -> null
+}
+
+fun iconForTypeId(typeId: Int?): ImageVector = when (typeId) {
+    1 -> Icons.Filled.Shield
+    2 -> Icons.Filled.Bolt
+    3 -> Icons.Filled.AddCircle
+    4 -> Icons.Filled.Healing
+    else -> Icons.Filled.Star
+}

--- a/app/src/main/java/com/example/leveluplife/ui/store/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/store/StoreDetailViewModel.kt
@@ -29,12 +29,12 @@ class StoreDetailViewModel(
         viewModelScope.launch {
             _state.update { it.copy(isPurchasing = true, purchaseError = null, purchaseSuccess = false) }
             repository.purchaseItem(item.id)
-                .onSuccess {
+                .onSuccess { response ->
                     _state.update { it.copy(isPurchasing = false, purchaseSuccess = true) }
                 }
                 .onFailure { t ->
                     val errorKey = when (t.message) {
-                        "insufficient_funds" -> "insufficient_funds"
+                        "insufficient_gold" -> "insufficient_gold"
                         else -> "generic"
                     }
                     _state.update { it.copy(isPurchasing = false, purchaseError = errorKey) }

--- a/app/src/main/java/com/example/leveluplife/ui/store/StoreScreen.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/store/StoreScreen.kt
@@ -21,12 +21,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Backpack
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Healing
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Shield
-import androidx.compose.material.icons.filled.ShoppingBag
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -73,6 +73,7 @@ internal val GoldColor = Color(0xFFF59E0B)
 @Composable
 fun StoreScreen(
     viewModel: StoreViewModel,
+    playerGold: Int,
     onBack: () -> Unit,
     onOpenInventory: () -> Unit,
     onPurchaseSuccess: () -> Unit = {},
@@ -94,7 +95,7 @@ fun StoreScreen(
 
     LaunchedEffect(state.buyError) {
         val key = state.buyError ?: return@LaunchedEffect
-        val msg = if (key == "insufficient_funds") errorInsufficient else errorGeneric
+        val msg = if (key == "insufficient_gold") errorInsufficient else errorGeneric
         snackbarHostState.showSnackbar(msg)
         viewModel.clearBuyError()
     }
@@ -119,8 +120,30 @@ fun StoreScreen(
                         }
                     },
                     actions = {
-                        IconButton(onClick = onOpenInventory) {
-                            Icon(Icons.Filled.ShoppingBag, contentDescription = stringResource(R.string.inventory_title))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(end = 4.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = null,
+                                tint = GoldColor,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text = stringResource(R.string.store_player_gold, playerGold),
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = GoldColor,
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            IconButton(onClick = onOpenInventory) {
+                                Icon(
+                                    Icons.Filled.Backpack,
+                                    contentDescription = stringResource(R.string.backpack_open_cd),
+                                )
+                            }
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
@@ -201,6 +224,7 @@ fun StoreScreen(
                     items(groupItems, key = { it.id }) { item ->
                         RewardItemCard(
                             item = item,
+                            playerGold = playerGold,
                             isBuying = item.id == state.buyingItemId,
                             anyBuying = state.buyingItemId != null,
                             onBuy = { viewModel.purchase(item) },
@@ -244,11 +268,15 @@ private fun SectionHeader(typeName: String, typeId: Int?) {
 @Composable
 private fun RewardItemCard(
     item: RewardItemDto,
+    playerGold: Int,
     isBuying: Boolean,
     anyBuying: Boolean,
     onBuy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val cost = item.costGold.toInt()
+    val canAfford = playerGold >= cost
+
     Card(
         shape = RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
@@ -291,7 +319,7 @@ private fun RewardItemCard(
                     )
                     Spacer(Modifier.width(2.dp))
                     Text(
-                        text = stringResource(R.string.store_cost_gold, item.costGold.toInt()),
+                        text = stringResource(R.string.store_cost_gold, cost),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.Bold,
                         color = GoldColor,
@@ -303,7 +331,7 @@ private fun RewardItemCard(
 
             Button(
                 onClick = onBuy,
-                enabled = !isBuying && !anyBuying,
+                enabled = canAfford && !isBuying && !anyBuying && item.isActive,
                 shape = RoundedCornerShape(8.dp),
                 modifier = Modifier
                     .height(36.dp)

--- a/app/src/main/java/com/example/leveluplife/ui/store/StoreViewModel.kt
+++ b/app/src/main/java/com/example/leveluplife/ui/store/StoreViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.leveluplife.data.network.dto.RewardItemDto
+import com.example.leveluplife.data.player.ProfileCache
 import com.example.leveluplife.data.rewards.RewardRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +14,7 @@ import kotlinx.coroutines.launch
 
 class StoreViewModel(
     private val repository: RewardRepository,
+    private val profileCache: ProfileCache,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(StoreUiState())
@@ -40,17 +42,18 @@ class StoreViewModel(
         viewModelScope.launch {
             _state.update { it.copy(buyingItemId = item.id, buyError = null, purchaseSuccessName = null) }
             repository.purchaseItem(item.id)
-                .onSuccess { inventoryItem ->
+                .onSuccess { response ->
+                    profileCache.setGold(response.remainingGold)
                     _state.update {
                         it.copy(
                             buyingItemId = null,
-                            purchaseSuccessName = inventoryItem.rewardItemName,
+                            purchaseSuccessName = response.inventory.rewardItemName,
                         )
                     }
                 }
                 .onFailure { t ->
                     val errorKey = when (t.message) {
-                        "insufficient_funds" -> "insufficient_funds"
+                        "insufficient_gold" -> "insufficient_gold"
                         else -> "generic"
                     }
                     _state.update { it.copy(buyingItemId = null, buyError = errorKey) }
@@ -63,11 +66,12 @@ class StoreViewModel(
 
     class Factory(
         private val repository: RewardRepository,
+        private val profileCache: ProfileCache,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(StoreViewModel::class.java))
-            return StoreViewModel(repository) as T
+            return StoreViewModel(repository, profileCache) as T
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,21 +438,40 @@
     <string name="store_detail_redeem_button">Canjear</string>
     <string name="store_detail_redeem_disabled">No disponible para canjear</string>
     <string name="store_redeem_coming_soon">Funcionalidad de canje próximamente disponible</string>
-    <string name="store_purchase_success">¡Item canjeado correctamente!</string>
-    <string name="store_purchase_success_button">¡Canjeado!</string>
-    <string name="store_purchase_error_insufficient">No tenés suficiente XP para este item</string>
+    <string name="store_purchase_success">¡Item comprado correctamente!</string>
+    <string name="store_purchase_success_button">¡Comprado!</string>
+    <string name="store_purchase_error_insufficient">No tenés suficiente oro para este item</string>
     <string name="store_purchase_error_not_found">Este item ya no está disponible</string>
-    <string name="store_purchase_error_generic">No se pudo completar el canje. Intentá de nuevo.</string>
+    <string name="store_purchase_error_generic">No se pudo completar la compra. Intentá de nuevo.</string>
     <string name="store_cost_gold">%1$d oro</string>
+    <string name="store_player_gold">%1$d oro</string>
     <string name="store_buy_button">Comprar</string>
     <string name="store_buy_success">¡%1$s comprado!</string>
-    <!-- Inventory -->
-    <string name="inventory_title">MI INVENTARIO</string>
+    <!-- Inventory / Mochila -->
+    <string name="inventory_title">MOCHILA</string>
     <string name="inventory_back">Volver</string>
-    <string name="inventory_empty">Tu inventario está vacío</string>
-    <string name="inventory_error">No se pudo cargar el inventario</string>
+    <string name="inventory_empty">Tu mochila está vacía</string>
+    <string name="inventory_error">No se pudo cargar la mochila</string>
     <string name="inventory_retry">Reintentar</string>
     <string name="inventory_quantity">x%1$d</string>
+    <string name="backpack_activate">Activar</string>
+    <string name="backpack_activating">Activando…</string>
+    <string name="backpack_equipped_badge">Equipado</string>
+    <string name="backpack_effects_title">EFECTOS ACTIVOS</string>
+    <string name="backpack_items_title">MIS OBJETOS</string>
+    <string name="backpack_effect_expires">Expira: %1$s</string>
+    <string name="backpack_effect_charges">Cargas: %1$d</string>
+    <string name="backpack_effect_multiplier">x%1$s</string>
+    <string name="backpack_activate_error_no_quantity">No quedan unidades de este item</string>
+    <string name="backpack_activate_error_already_active">Este item ya tiene un efecto activo</string>
+    <string name="backpack_activate_error_recovery">No hay racha o penalización que recuperar</string>
+    <string name="backpack_activate_error_generic">No se pudo activar el item. Intentá de nuevo.</string>
+    <string name="backpack_open_cd">Abrir mochila</string>
+    <!-- Home gold -->
+    <string name="home_gold_chip">%1$d oro</string>
+    <string name="home_gold_content_description">%1$d oro</string>
+    <!-- Task completion -->
+    <string name="task_reward_gold_earned">+%1$d oro</string>
 
     <!-- Evidence gallery - delete -->
     <string name="evidence_gallery_delete_button">Eliminar</string>

--- a/app/src/test/java/com/example/leveluplife/data/network/dto/InventoryResponseDtoTest.kt
+++ b/app/src/test/java/com/example/leveluplife/data/network/dto/InventoryResponseDtoTest.kt
@@ -1,0 +1,41 @@
+package com.example.leveluplife.data.network.dto
+
+import com.example.leveluplife.data.network.NetworkModule
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InventoryResponseDtoTest {
+
+    private val json = NetworkModule.jsonParser()
+
+    @Test
+    fun `decodes wrapped inventory response from backend`() {
+        val response = json.decodeFromString<InventoryResponseDto>(
+            """
+            {
+              "items": [
+                {
+                  "id": 1,
+                  "playerUserId": 2,
+                  "rewardItemId": 1,
+                  "rewardItemName": "Escudo 1 día",
+                  "rewardItemTypeId": 1,
+                  "rewardItemTypeName": "Protección de racha",
+                  "costGold": 30,
+                  "effectValue": 1,
+                  "quantity": 1,
+                  "isEquipped": false,
+                  "acquiredAt": "2026-06-20T02:57:07.143016-06:00"
+                }
+              ],
+              "activeEffects": []
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(1, response.items.size)
+        assertEquals("Escudo 1 día", response.items.first().rewardItemName)
+        assertEquals(2, response.items.first().playerUserId)
+        assertEquals(0, response.activeEffects.size)
+    }
+}

--- a/app/src/test/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/habittaskdetail/HabitTaskDetailViewModelTest.kt
@@ -99,6 +99,8 @@ class HabitTaskDetailViewModelTest {
 
         assertEquals(1, taskRepo.completeCalls)
         assertEquals(3, profileCache.lastLevel)
+        assertEquals(25, profileCache.lastGoldEarned)
+        assertEquals(25, profileCache.profile.value?.gold)
         assertEquals(25, vm.state.value.reward?.xpEarned)
         assertEquals(2, vm.state.value.reward?.previousLevel)
         assertEquals(3, vm.state.value.reward?.newLevel)
@@ -286,6 +288,7 @@ class HabitTaskDetailViewModelTest {
         )
         override val profile: StateFlow<PlayerProfile?> = _profile
         var lastLevel: Int = level
+        var lastGoldEarned: Int = 0
 
         override suspend fun loadPersisted() = Unit
 
@@ -318,6 +321,15 @@ class HabitTaskDetailViewModelTest {
                 levelProgressPercent = levelProgressPercent,
                 daysStreak = daysStreak ?: _profile.value.daysStreak,
             )
+        }
+
+        override suspend fun addGoldEarned(amount: Int) {
+            lastGoldEarned = amount
+            _profile.value = _profile.value.copy(gold = _profile.value.gold + amount)
+        }
+
+        override suspend fun setGold(gold: Int) {
+            _profile.value = _profile.value.copy(gold = gold)
         }
 
         override fun clearMemory() = Unit

--- a/app/src/test/java/com/example/leveluplife/ui/profile/ProfileTestFixtures.kt
+++ b/app/src/test/java/com/example/leveluplife/ui/profile/ProfileTestFixtures.kt
@@ -111,6 +111,17 @@ class FakeProfileCache(
         )
     }
 
+    override suspend fun addGoldEarned(amount: Int) {
+        if (amount <= 0) return
+        val current = _profile.value ?: return
+        _profile.value = current.copy(gold = current.gold + amount)
+    }
+
+    override suspend fun setGold(gold: Int) {
+        val current = _profile.value ?: return
+        _profile.value = current.copy(gold = gold)
+    }
+
     override fun clearMemory() {
         _profile.value = null
         etag = null
@@ -134,6 +145,7 @@ fun sampleProfile() = PlayerProfile(
     email = "aarontest@leveluplife.com",
     birthdate = "2000-01-15",
     bio = "Hola",
+    gold = 300,
 )
 
 fun validationException() = ProfileException(


### PR DESCRIPTION
# Economy (Gold), Store, Backpack & Effects Integration

Step-by-step documentation of the changes made to the **LevelUpLife** frontend to align the app with the backend `rewards_and_effects` branch.

---

## Context & Goals

The backend exposes:

- **Gold (`gold`)** on the player profile.
- **Store** of reward items (`RewardItem`) with purchases that deduct gold.
- **Inventory / backpack** with acquired items and **active effects**.
- **Activation** of inventory items (shields, boosters, streak recovery, etc.).

The frontend needed to:

1. Display and persist the player's gold balance.
2. Allow store purchases with sufficient-balance validation.
3. Show the backpack with items and active effects (it previously appeared empty).
4. Earn gold when completing missions (`gold += xpEarned`).
5. **Preserve the previous visual design** of the store and gold UI (no full UI rewrite).

---

## Step 1 — Data Model: Gold on Profile

### Modified Files

| File | Change |
|------|--------|
| `data/player/PlayerProfile.kt` | Added `gold: Int = 0` |
| `data/network/dto/PlayerProfileDtos.kt` | Added `gold` to `GetPlayerProfileResponseDto` |
| `data/player/ProfileRepository.kt` | Maps `gold` in `toDomain()` |
| `data/player/ProfileCache.kt` | Added `addGoldEarned(amount)` and `setGold(gold)` + DataStore persistence |

### What Each Piece Does

1. **`PlayerProfile`**: local player domain now includes gold balance.
2. **Profile DTO**: `GET /api/PlayerProfile` returns `gold` and it is deserialized.
3. **`ProfileRepository`**: converts the DTO to domain including `gold`.
4. **`ProfileCache`**:
   - `addGoldEarned(n)`: adds `n` to gold in memory and persists it (used on mission completion).
   - `setGold(n)`: sets the exact gold amount (used after purchase when the backend returns `remainingGold`).

---

## Step 2 — New Reward & Inventory DTOs

### File: `data/network/dto/RewardItemDto.kt`

Extended and added the following types:

| DTO | Purpose |
|-----|---------|
| `RewardItemDto` | Store item; added `durationDays` |
| `PlayerInventoryDto` | Player inventory row |
| `ActiveEffectDto` | Active effect derived from an item |
| `InventoryResponseDto` | Wrapped response `{ items, activeEffects }` |
| `PurchaseResponseDto` | Purchase response: `{ inventory, remainingGold }` |
| `ActivateItemResponseDto` | Activate response: `{ inventory, activeEffect, recoveryMessage }` |

`InventoryResponseDto` uses `@JsonNames` to accept both camelCase and PascalCase from the backend:

```kotlin
@JsonNames("items", "Items") val items: ...
@JsonNames("activeEffects", "ActiveEffects") val activeEffects: ...
```

---

## Step 3 — Rewards API (Retrofit)

### File: `data/network/RewardApi.kt`

Endpoints aligned with the backend:

| Method | Route | Response |
|--------|-------|----------|
| `GET` | `api/RewardItem` | `List<RewardItemDto>` |
| `POST` | `api/RewardItem/{itemId}/purchase` | `PurchaseResponseDto` |
| `GET` | `api/RewardItem/inventory` | `ResponseBody` (raw) |
| `POST` | `api/RewardItem/inventory/{inventoryId}/activate` | `ActivateItemResponseDto` |

**Important note:** inventory uses `ResponseBody` instead of deserializing directly to `List<PlayerInventoryDto>`, because the backend returns a **wrapped object**, not a flat array.

---

## Step 4 — Rewards Repository

### File: `data/rewards/RewardRepository.kt`

### 4.1 Store Listing

`getRewardItems()` — logic unchanged; still returns the item list.

### 4.2 Purchase

`purchaseItem(itemId)` returns `PurchaseResponseDto`. HTTP 400 errors are mapped to UI keys:

- `insufficient_gold` — not enough gold
- `generic` — any other error

### 4.3 Inventory (Critical Fix for Empty Backpack)

`getInventory()`:

1. Calls `api.getInventoryRaw()`.
2. Reads JSON as text.
3. Parses with `parseInventoryResponse()` supporting **three formats**:

```
Format A (current backend):
{ "items": [...], "activeEffects": [...] }

Format B (PascalCase):
{ "Items": [...], "ActiveEffects": [...] }

Format C (legacy / flat array):
[ { id: 1, ... }, { id: 2, ... } ]
```

This was the **main bug**: Retrofit tried to deserialize the wrapped object as a `List` and either failed silently or returned an empty list.

### 4.4 Item Activation

`activateItem(inventoryId)` returns `ActivateItemResponseDto`. HTTP 400 errors mapped to:

| Key | Meaning |
|-----|---------|
| `no_quantity` | No units available |
| `effect_already_active` | Effect is already active |
| `recovery_no_target` | No streak/penalty to recover |
| `generic` | Generic error |

---

## Step 5 — Shared UI Utilities

### File: `ui/rewards/RewardItemUi.kt`

Extracted common code between Store and Backpack:

- `GoldColor` — amber color `#F59E0B` for gold chips.
- `drawableForItemId(id)` — local drawable by item ID (shields, boosters, upgrades).
- `iconForTypeId(typeId)` — Material icon by effect type.

Avoids duplicating image logic that already existed in the store.

---

## Step 6 — Home Screen: Gold & Backpack Access

### File: `ui/home/HomeScreen.kt`

### 6.1 Gold Chip

In the stats row (`EngagementStatsRow`), alongside streak and XP:

```
[ 🔥 5 days ]  [ ⭐ 120 XP ]  [ 💰 160 gold ]
```

Private component `GoldChip(gold: Int)` using `GoldColor` and string `home_gold_chip`.

### 6.2 Backpack Icon in Header

In the Home top bar, between **Categories** and **Profile**:

```
Categories  |  🎒 Backpack  |  👤 Profile
```

New callback `onOpenBackpack: () -> Unit` wired to `Icons.Filled.Backpack`.

---

## Step 7 — Navigation

### File: `ui/navigation/AppNavigation.kt`

| Route | Screen |
|-------|--------|
| `Routes.INVENTORY` (`"inventory"`) | `InventoryScreen` |

Wiring:

- Home → `onOpenBackpack` navigates to `INVENTORY`.
- Store → backpack icon navigates to `INVENTORY`.
- Store receives `playerGold = cachedProfile?.gold ?: 0` from `profileCache`.
- `StoreViewModel.Factory` injects `ProfileCache` in addition to `RewardRepository`.

---

## Step 8 — Store (Original Design Preserved)

### Files: `ui/store/StoreScreen.kt`, `StoreViewModel.kt`, `StoreDetailScreen.kt`, `StoreDetailViewModel.kt`

### Minimal Changes on Top of Existing Design

1. **Gold balance** in the top bar (`store_player_gold`).
2. **Buy button disabled** when `playerGold < item.costGold`.
3. **Backpack icon** in the top bar to open inventory.
4. Error key `insufficient_gold` → *"No tenés suficiente oro para este item"* (Spanish UI string).

### Purchase Flow (`StoreViewModel`)

```
User taps Buy
  → rewardRepository.purchaseItem(itemId)
  → onSuccess: profileCache.setGold(response.remainingGold)
  → UI reflects new balance via profileCache StateFlow
```

Store cards, images (`drawableForItemId`), and layout were **not rewritten**.

---

## Step 9 — Backpack Screen (Inventory)

### Files

| File | Role |
|------|------|
| `ui/inventory/InventoryScreen.kt` | Full UI |
| `ui/inventory/InventoryViewModel.kt` | Load & activate |
| `ui/inventory/InventoryUiState.kt` | Screen state |

### Screen Layout

```
┌─────────────────────────────┐
│  ← Back        BACKPACK     │
├─────────────────────────────┤
│  ACTIVE EFFECTS             │
│  [ effect 1 ] [ effect 2 ]  │
├─────────────────────────────┤
│  MY ITEMS                   │
│  [ item ] x2  [Activate]    │
│  [ item ] x1  [Activate]    │
└─────────────────────────────┘
```

### ViewModel

- `load()`: calls `rewardRepository.getInventory()`, stores `items` and `activeEffects` in state.
- `activate(inventoryId)`: calls `rewardRepository.activateItem()`, reloads inventory and shows `recoveryMessage` when applicable.
- Error handling with keys translated via `strings.xml`.

### Images

Reuses `drawableForItemId` and `iconForTypeId` from `RewardItemUi.kt`.

---

## Step 10 — Gold on Mission Completion

### Files

| File | Change |
|------|--------|
| `ui/habittaskdetail/HabitTaskDetailViewModel.kt` | After task completion: `profileCache.addGoldEarned(response.xpEarned)` |
| `ui/habittaskdetail/TaskCompletionRewardDialog.kt` | `+%d gold` line using string `task_reward_gold_earned` |

### Business Rule

When completing a mission/habit, gold earned equals XP earned for that action:

```
gold += xpEarned
```

Gold updates in local cache immediately; the Home chip reflects the change without reloading the profile.

---

## Step 11 — Strings (Spanish UI)

### File: `app/src/main/res/values/strings.xml`

**Inventory / Backpack** section:

- Titles, empty state, errors, Activate button, badges, active effects.

**Home gold** section:

- `home_gold_chip`, `home_gold_content_description`, `task_reward_gold_earned`.

**Store**:

- Purchase errors updated from "XP" to **"oro" (gold)** (`store_purchase_error_insufficient`, `store_cost_gold`, `store_player_gold`).

> Note: app UI strings remain in Spanish; only this documentation is in English.

---

## Step 12 — Tests

### Updated / Created Files

| File | What It Tests |
|------|---------------|
| `test/.../InventoryResponseDtoTest.kt` | Deserialization of `{ items, activeEffects }` |
| `test/.../ProfileTestFixtures.kt` | `FakeProfileCache` with `addGoldEarned` / `setGold`; `sampleProfile.gold = 300` |
| `test/.../HabitTaskDetailViewModelTest.kt` | Verifies `addGoldEarned` is called with XP earned on mission completion |

---

## Overall Flow Diagram

```mermaid
flowchart TD
    subgraph Profile
        API_PROFILE[GET PlayerProfile] --> ProfileRepo
        ProfileRepo --> ProfileCache
        ProfileCache --> HomeGold[GoldChip on Home]
        ProfileCache --> StoreGold[Balance in Store]
    end

    subgraph Store
        StoreVM[StoreViewModel] --> PurchaseAPI[POST purchase]
        PurchaseAPI --> SetGold[profileCache.setGold remainingGold]
    end

    subgraph Missions
        TaskVM[HabitTaskDetailViewModel] --> CompleteAPI[POST complete]
        CompleteAPI --> AddGold[profileCache.addGoldEarned xpEarned]
        AddGold --> RewardDialog[Reward dialog +X gold]
    end

    subgraph Backpack
        InvVM[InventoryViewModel] --> InvAPI[GET inventory raw JSON]
        InvAPI --> Parse[parseInventoryResponse]
        Parse --> InvScreen[InventoryScreen]
        InvScreen --> ActivateAPI[POST activate]
    end
```

---

## Issues Found & Fixes

| Issue | Cause | Fix |
|-------|-------|-----|
| Empty backpack with items in DB | Backend returns `{ items, activeEffects }`, frontend expected `List` | Manual parse with `ResponseBody` |
| Store with no items | Stale local cache / outdated DB | Refresh; not a code bug |
| Gold / design "disappeared" | Partial refactors overwrote UI | Restore original store design + add only gold chip and validation |
| Errors said "XP" | Old strings | Updated to "oro" (gold) in `strings.xml` |

---

## Files Touched (Summary)

```
data/
  network/
    RewardApi.kt
    dto/
      RewardItemDto.kt
      PlayerProfileDtos.kt
  player/
    PlayerProfile.kt
    ProfileRepository.kt
    ProfileCache.kt
  rewards/
    RewardRepository.kt

ui/
  rewards/
    RewardItemUi.kt          ← new (shared util)
  home/
    HomeScreen.kt
  store/
    StoreScreen.kt
    StoreViewModel.kt
    StoreDetailScreen.kt
    StoreDetailViewModel.kt
  inventory/
    InventoryScreen.kt
    InventoryViewModel.kt
    InventoryUiState.kt
  habittaskdetail/
    HabitTaskDetailViewModel.kt
    TaskCompletionRewardDialog.kt
  navigation/
    AppNavigation.kt

res/values/
  strings.xml

test/
  data/network/dto/InventoryResponseDtoTest.kt
  ui/profile/ProfileTestFixtures.kt
  ui/habittaskdetail/HabitTaskDetailViewModelTest.kt
```

---

## Manual Verification Checklist

1. **Log in** as a player with gold and inventory items (e.g. F3N, id 2, gold=160).
2. **Home**: gold chip and backpack icon visible in the header.
3. **Store**: balance visible; Buy button disabled when gold is insufficient.
4. **Purchase** an item: gold drops to backend `remainingGold`; item appears in backpack.
5. **Backpack**: "MY ITEMS" section shows items; "ACTIVE EFFECTS" when any exist.
6. **Activate** an item: effect moves to active list; translated errors on failure.
7. **Complete mission**: dialog shows `+X gold`; Home chip increases by the same amount as XP.

---

## Remaining / Notes

- Run `./gradlew :app:compileDebugKotlin` and unit tests to confirm no missing stubs (e.g. `PomodoroViewModelTest.deleteHabit`).
- `StoreDetailScreen` should receive `playerGold` if using a standalone detail flow.
- Consider removing `PurchasedItemStorage.kt` if obsolete after migrating to the backend.

---

*Document generated from the frontend ↔ backend `rewards_and_effects` integration work.*
